### PR TITLE
interface: make async_call_ready variable local to Proxy function ins…

### DIFF
--- a/interfaces/cpp.xsl
+++ b/interfaces/cpp.xsl
@@ -360,7 +360,7 @@
             <xsl:text>  int timeout_msec = -1;&#10;</xsl:text> 
             <xsl:text>  Gio::DBus::CallFlags flags = Gio::DBus::CALL_FLAGS_NONE;&#10;</xsl:text>
             <xsl:text>  Glib::VariantType  reply_type;&#10;</xsl:text>
-            <xsl:text>  async_call_ready = false;&#10;</xsl:text>
+            <xsl:text>  bool async_call_ready = false;&#10;</xsl:text>
             <xsl:text>  Glib::RefPtr&lt;Glib::MainLoop&gt;    mainloop = Glib::MainLoop::create();&#10;</xsl:text>
             <xsl:text>  Glib::RefPtr&lt;Glib::MainContext&gt; context  = mainloop-&gt;get_context();&#10;&#10;</xsl:text>
 
@@ -397,9 +397,9 @@
             <xsl:value-of select="@name"/>
             <xsl:text>",&#10;</xsl:text>
             <xsl:text>      query,&#10;</xsl:text>
-            <xsl:text>      sigc::bind(sigc::mem_fun(this, &amp;i</xsl:text> 
+            <xsl:text>      sigc::bind(sigc::bind(sigc::mem_fun(this, &amp;i</xsl:text> 
             <xsl:value-of select="$iface"/>
-            <xsl:text>_Proxy::AsyncCallReady), &amp;response),&#10;</xsl:text>
+            <xsl:text>_Proxy::AsyncCallReady), &amp;response), &amp;async_call_ready),&#10;</xsl:text>
             <xsl:text>      cancellable,&#10;</xsl:text>
             <xsl:text>      fd_list,&#10;</xsl:text>
             <xsl:text>      "de.gsi.saftlib",&#10;</xsl:text>
@@ -483,13 +483,13 @@
       <!-- <xsl:variable name="void" select="count(arg[@direction='out']) != 1"/> -->
       <xsl:text>void i</xsl:text><xsl:value-of select="$iface"/><xsl:text>_Proxy::</xsl:text>
       <!-- <xsl:value-of select="@name"/> -->
-      <xsl:text>AsyncCallReady(Glib::RefPtr&lt;Gio::AsyncResult&gt;&amp; async_result, Glib::VariantContainerBase *result)</xsl:text>
+      <xsl:text>AsyncCallReady(Glib::RefPtr&lt;Gio::AsyncResult&gt;&amp; async_result, bool *async_call_ready, Glib::VariantContainerBase *result)</xsl:text>
       <xsl:text>&#10;</xsl:text>
       <xsl:text>{&#10;</xsl:text>
       <xsl:text>    auto connection = get_connection();&#10;</xsl:text>
       <xsl:text>    connection-&gt;reference();&#10;</xsl:text>
       <xsl:text>    *result = connection-&gt;call_finish(async_result);&#10;</xsl:text>
-      <xsl:text>    async_call_ready = true;&#10;</xsl:text>
+      <xsl:text>    *async_call_ready = true;&#10;</xsl:text>
       <xsl:text>}&#10;&#10;</xsl:text>
 
       <!-- Boiler-plate to retrieve a property -->
@@ -739,6 +739,12 @@
         <xsl:if test="not(count(arg[substring(@type,1,1)='A'])=0) or not(count(arg[@type='h'])=0)">
           <xsl:text>      Glib::RefPtr&lt;Gio::DBus::Message&gt; message = invocation-&gt;get_message();&#10;</xsl:text>
           <xsl:text>      GUnixFDList *fd_list  = g_dbus_message_get_unix_fd_list(message-&gt;gobj());&#10;</xsl:text>
+          <xsl:text>      if (!fd_list) { &#10;</xsl:text>
+          <xsl:text>        throw Gio::DBus::Error(Gio::DBus::Error::INVALID_ARGS, "No filedescriptors received");&#10;</xsl:text>
+          <xsl:text>      }&#10;</xsl:text>
+          <xsl:text>      if (g_unix_fd_list_get_length(fd_list) != 2) { &#10;</xsl:text>
+          <xsl:text>        throw Gio::DBus::Error(Gio::DBus::Error::INVALID_ARGS, "Wrong number of file descriptors received");&#10;</xsl:text>
+          <xsl:text>      }&#10;</xsl:text>
           <xsl:text>      int fd_index = 0;&#10;</xsl:text>
           <xsl:if test="not(count(arg[substring(@type,1,1)='A'])=0)">
             <xsl:text>      gint _vector_pipe_fd0 = g_unix_fd_list_get(fd_list, fd_index++, 0);&#10;</xsl:text>

--- a/interfaces/h.xsl.in
+++ b/interfaces/h.xsl.in
@@ -413,12 +413,10 @@
 
 
       <!-- Create AsyncCallReady function declaration -->
-      <xsl:text>void </xsl:text>
-      <xsl:text>AsyncCallReady(Glib::RefPtr&lt;Gio::AsyncResult&gt;&amp; async_result, Glib::VariantContainerBase *result);&#10;&#10;</xsl:text>
+      <xsl:text>    void </xsl:text>
+      <xsl:text>AsyncCallReady(Glib::RefPtr&lt;Gio::AsyncResult&gt;&amp; async_result, bool *async_call_ready, Glib::VariantContainerBase *result);&#10;&#10;</xsl:text>
 
       <xsl:text>    // notification if async DBus call is completed&#10;</xsl:text>
-      <xsl:text>    bool async_call_ready;&#10;</xsl:text>
-
 
       <!-- Implementation -->
   protected:


### PR DESCRIPTION
…tead of a private member

This variable beeing a private member might cause dead locks if the proxy function is called asyncronously from multiple threads. Making it local to the function should prevent that, because each thread would have its own version of that variable on the thread-local stack.
Also, an error message is created if a function that expects file descriptors does not get any file descriptors.