### PR TITLE
Fixed the sequence of signals generated when a function generator stops.

### DIFF
--- a/drivers/FunctionGeneratorImpl.cpp
+++ b/drivers/FunctionGeneratorImpl.cpp
@@ -261,10 +261,9 @@ void FunctionGeneratorImpl::irq_handler(eb_data_t msi)
       }
       executedParameterCount = ReadExecutedParameterCount();
       running = false;
-
-      releaseChannel();
       signal_running.emit(running);
       signal_stopped.emit(time, abort, hardwareMacroUnderflow, microControllerUnderflow);
+      releaseChannel();
     }
   }
 }


### PR DESCRIPTION
Stop now generated before Enabled(false). saft-fg-ctl would previously stop when receiving the Enabled signal and therefore not receive the Stop signal. 