### PR TITLE
Changed MasterFunctionGenerator interface replacing vector<bool> with vector<int>

### DIFF
--- a/drivers/MasterFunctionGenerator.cpp
+++ b/drivers/MasterFunctionGenerator.cpp
@@ -434,23 +434,23 @@ std::vector<Glib::ustring> MasterFunctionGenerator::ReadNames()
 	return names;
 }
 
-
-std::vector<bool> MasterFunctionGenerator::ReadArmed()
+// vector<bool> as used in glib 2.50 requires c++14 
+std::vector<int> MasterFunctionGenerator::ReadArmed()
 {
-	std::vector<bool> armed_states;
+	std::vector<int> armed_states;
 	for (auto fg : activeFunctionGenerators)
 	{
-	  armed_states.push_back(fg->getArmed());
+	  armed_states.push_back(fg->getArmed() ? 1 : 0);
 	}
 	return armed_states;
 }
 
-std::vector<bool> MasterFunctionGenerator::ReadEnabled()
+std::vector<int> MasterFunctionGenerator::ReadEnabled()
 {
-	std::vector<bool> enabled_states;
+	std::vector<int> enabled_states;
 	for (auto fg : activeFunctionGenerators)
 	{
-	  enabled_states.push_back(fg->getEnabled());
+	  enabled_states.push_back(fg->getEnabled() ? 1 : 0);
 	}
 	return enabled_states;
 }

--- a/drivers/MasterFunctionGenerator.h
+++ b/drivers/MasterFunctionGenerator.h
@@ -59,8 +59,8 @@ class MasterFunctionGenerator : public Owned, public iMasterFunctionGenerator
 
     std::vector<Glib::ustring> ReadAllNames();
     std::vector<Glib::ustring> ReadNames();
-    std::vector<bool> ReadArmed();
-    std::vector<bool> ReadEnabled();
+    std::vector<int> ReadArmed();
+    std::vector<int> ReadEnabled();
     void ResetActiveFunctionGenerators();
     void SetActiveFunctionGenerators(const std::vector<Glib::ustring>&);
 

--- a/interfaces/MasterFunctionGenerator.xml
+++ b/interfaces/MasterFunctionGenerator.xml
@@ -263,14 +263,14 @@
       -->
     
     <method name="ReadArmed">
-      <arg direction="out" type="ab" name="armed_states"/>
+      <arg direction="out" type="ai" name="armed_states"/>
     </method>
 
     <!-- ReadEnabled: Read the enabled state of each active FG.
          @enabled_states:       State of each FG.
       -->
     <method name="ReadEnabled">
-      <arg direction="out" type="ab" name="enabled_states"/>
+      <arg direction="out" type="ai" name="enabled_states"/>
     </method>
 
   </interface>

--- a/src/saft-mfg-ctl.cpp
+++ b/src/saft-mfg-ctl.cpp
@@ -462,8 +462,8 @@ void test_master_fg(Glib::RefPtr<Glib::MainLoop> loop,Glib::RefPtr<SCUbusActionS
     
     Glib::RefPtr<Glib::MainContext> context  = loop->get_context();
 
-    vector<bool> enabled_gens = master_gen->ReadEnabled();
-    while (std::find(enabled_gens.begin(), enabled_gens.end(), true) != enabled_gens.end()) 
+    vector<int> enabled_gens = master_gen->ReadEnabled();
+    while (std::find(enabled_gens.begin(), enabled_gens.end(), 1) != enabled_gens.end()) 
     {      
       context->iteration(false);
       enabled_gens = master_gen->ReadEnabled();


### PR DESCRIPTION
Changes in glibmm 2.50 cause vector<bool> to use a vector emplace that requires c++14. 