### PR TITLE
Prevent an fg reset if a reset has already been started but not yet been acknowledged.

### DIFF
--- a/drivers/FunctionGeneratorImpl.cpp
+++ b/drivers/FunctionGeneratorImpl.cpp
@@ -508,6 +508,7 @@ bool FunctionGeneratorImpl::ResetFailed()
 void FunctionGeneratorImpl::Reset()
 {
   if (channel == -1) return; // nothing to abort
+  if (resetTimeout.connected()) return; // reset already in progress
   dev->getDevice().write(swi, EB_DATA32, SWI_DISABLE | channel);
   // expect disarm or started+stopped, but if not ... timeout:
   resetTimeout = Glib::signal_timeout().connect(


### PR DESCRIPTION
If an FG is reset twice in rapid succession (before the first interrupt triggered by the reset has been received), the second reset will timeout and cause an assertion failure in ResetFailed (since enabled=false)  which immediately terminates saftd.