### PR TITLE
gw-version: added method and property to obtain gateware version string

### DIFF
--- a/drivers/TimingReceiver.cpp
+++ b/drivers/TimingReceiver.cpp
@@ -25,6 +25,7 @@
 
 #include <sstream>
 #include <algorithm>
+#include <map>
 
 #include "RegisteredObject.h"
 #include "Driver.h"
@@ -52,6 +53,7 @@ TimingReceiver::TimingReceiver(const ConstructorType& args)
    device(args.device),
    name(args.name),
    etherbonePath(args.etherbonePath),
+   
    base(args.base.sdb_component.addr_first),
    stream(args.stream),
    watchdog(args.watchdog),
@@ -314,6 +316,26 @@ void TimingReceiver::setupGatewareInfo(guint32 address)
 std::map< Glib::ustring, Glib::ustring > TimingReceiver::getGatewareInfo() const
 {
   return info;
+}
+
+Glib::ustring TimingReceiver::getGatewareVersion() const
+{
+  std::map< Glib::ustring, Glib::ustring >         gatewareInfo;
+  std::map<Glib::ustring, Glib::ustring>::iterator j;
+  Glib::ustring                                    rawVersion;
+  Glib::ustring::size_type                         pos;
+
+  gatewareInfo = getGatewareInfo();
+  j = gatewareInfo.begin();  // build date
+  j++;                       // gateware version
+  rawVersion = j->second;
+  pos = rawVersion.find("-v",0);
+
+  if ((pos <= 0) || (pos >= rawVersion.length())) return ("N/A");
+
+  pos = pos + 2;             // get rid of '-v'
+  
+  return(rawVersion.substr(pos, rawVersion.length() - pos));
 }
 
 bool TimingReceiver::getLocked() const

--- a/drivers/TimingReceiver.cpp
+++ b/drivers/TimingReceiver.cpp
@@ -323,17 +323,18 @@ Glib::ustring TimingReceiver::getGatewareVersion() const
   std::map< Glib::ustring, Glib::ustring >         gatewareInfo;
   std::map<Glib::ustring, Glib::ustring>::iterator j;
   Glib::ustring                                    rawVersion;
-  Glib::ustring::size_type                         pos;
+  Glib::ustring                                    findString = "-v";
+  int                                              pos = 0;
 
   gatewareInfo = getGatewareInfo();
-  j = gatewareInfo.begin();  // build date
-  j++;                       // gateware version
+  j = gatewareInfo.begin();        // build date
+  j++;                             // gateware version
   rawVersion = j->second;
-  pos = rawVersion.find("-v",0);
+  pos = rawVersion.find(findString, 0);
 
-  if ((pos <= 0) || (pos >= rawVersion.length())) return ("N/A");
+  if ((pos <= 0) || (((pos + findString.length()) >= rawVersion.length()))) return ("N/A");
 
-  pos = pos + 2;             // get rid of '-v'
+  pos = pos + findString.length(); // get rid of findString '-v'
   
   return(rawVersion.substr(pos, rawVersion.length() - pos));
 }

--- a/drivers/TimingReceiver.h
+++ b/drivers/TimingReceiver.h
@@ -56,6 +56,7 @@ class TimingReceiver : public BaseObject, public iTimingReceiver, public iDevice
     void InjectEvent(guint64 event, guint64 param, guint64 time);
     guint64 ReadCurrentTime();
     std::map< Glib::ustring, Glib::ustring > getGatewareInfo() const;
+    Glib::ustring getGatewareVersion() const;
     bool getLocked() const;
     std::map< Glib::ustring, Glib::ustring > getSoftwareActionSinks() const;
     std::map< Glib::ustring, Glib::ustring > getOutputs() const;

--- a/interfaces/TimingReceiver.xml
+++ b/interfaces/TimingReceiver.xml
@@ -31,11 +31,19 @@
        SCUbusActionSink key, and as there is only one, it would be the 0th.
     -->
   <interface name="de.gsi.saftlib.TimingReceiver">
-  
+
+
     <!-- GatewareInfo: Key-value map of hardware build information -->
     <property name="GatewareInfo" type="a{ss}" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
     </property>
+
+    <!-- GatewareVersion: Hardware build version
+
+         Returns "major.minor.tiny" if version is valid (or "N/A" if not available)
+    -->
+    <property name="GatewareVersion" type="s" access="read"/>
+
     
     <!-- Locked: The timing receiver is locked to the timing grandmaster.
          Upon power-up it takes approximately one minute until the timing

--- a/src/saft-ctl.cpp
+++ b/src/saft-ctl.cpp
@@ -73,6 +73,7 @@ static void help(void) {
   std::cout << "  -p                   used with command 'inject': <time> will be added to next full second (option -p) or current time (option unused)" << std::endl; 
   std::cout << "  -i                   display saftlib info" << std::endl;
   std::cout << "  -j                   list all attached devices (hardware)" << std::endl;
+  std::cout << "  -k                   display gateware version (hardware)" << std::endl;
   std::cout << "  -s                   display actual status of software actions" << std::endl;
   std::cout << std::endl;
   std::cout << "  inject <eventID> <param> <time>  inject event locally, time [ns] is relative (see option -p for precise timing)" << std::endl;
@@ -200,6 +201,7 @@ static void displayInfoHW(Glib::RefPtr<SAFTd_Proxy> saftd) {
     std::cout << "  device: " << i->second;
     std::cout << ", name: " << aDevice->getName();
     std::cout << ", path: " << aDevice->getEtherbonePath();
+    std::cout << ", gatewareVersion : " << aDevice->getGatewareVersion();
     std::cout << std::endl;
     gatewareInfo = aDevice->getGatewareInfo();
     std::cout << "  --gateware version info:" << std::endl;
@@ -211,6 +213,12 @@ static void displayInfoHW(Glib::RefPtr<SAFTd_Proxy> saftd) {
 } // displayInfoHW
 
 
+static void displayInfoGW(Glib::RefPtr<TimingReceiver_Proxy> receiver)
+{
+  std::cout << receiver->getGatewareVersion() << std::endl;
+} // displayInfoGW
+
+
 int main(int argc, char** argv)
 {
   // variables and flags for command line parsing
@@ -219,6 +227,7 @@ int main(int argc, char** argv)
   bool statusDisp     = false;
   bool infoDispSW     = false;
   bool infoDispHW     = false;
+  bool infoDispGW     = false;
   bool ppsAlign       = false;
   bool eventInject    = false;
   bool deviceAttach   = false;
@@ -251,7 +260,7 @@ int main(int argc, char** argv)
 
   // parse for options
   program = argv[0];
-  while ((opt = getopt(argc, argv, "dxsvpijhf")) != -1) {
+  while ((opt = getopt(argc, argv, "dxsvpijkhf")) != -1) {
     switch (opt) {
     case 'f' :
       useFirstDev = true;
@@ -264,6 +273,9 @@ int main(int argc, char** argv)
       break;
     case 'j':
       infoDispHW = true;
+      break;
+    case 'k':
+      infoDispGW = true;
       break;
     case 'p':
       ppsAlign = true;
@@ -435,6 +447,8 @@ int main(int argc, char** argv)
     default :
       return 1;
     } //switch useFirstDevice;
+
+    if (infoDispGW) displayInfoGW(receiver);
     
     
     Glib::RefPtr<SoftwareActionSink_Proxy> sink = SoftwareActionSink_Proxy::create(receiver->NewSoftwareActionSink(""));


### PR DESCRIPTION
Please check. Code just parses gw-info -> build type for "-v".

Gateware version is now available as property of Timing Receiver.

 