### PR TITLE
Safe fg scan

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,12 +58,19 @@ if test "x$XSLTPROC" = "x"; then
 fi
 
 dnl Generate documentation, only if we can
-AC_PATH_PROGS([DOCBOOK2PDF], [docbook2pdf])
+AC_PATH_PROGS([DOCBOOK2TEXI], [docbook2texi])
+AC_PATH_PROGS([TEXI2PDF], [texi2pdf])
+AC_PATH_PROGS([GDBUS_CODEGEN], [gdbus-codegen])
 AC_PATH_PROGS([DOCBOOK2MAN], [docbook2man])
 AC_PATH_PROGS([GIT], [git])
 
+AC_ARG_ENABLE([pdf-doc], 
+              [AS_HELP_STRING([--enable-pdf-doc], [generate pdf documentation of interfaces])], 
+              [ENABLE_PDF_DOC=yes], 
+              []
+             )
 
-AM_CONDITIONAL([INTERFACE_DOCS], [test x$DOCBOOK2PDF != x -a x$GDBUS_CODEGEN != x])
+AM_CONDITIONAL([INTERFACE_DOCS], [test x$ENABLE_PDF_DOC != x -a x$DOCBOOK2TEXI != x -a x$TEXI2PDF != x -a x$GDBUS_CODEGEN != x])
 AM_CONDITIONAL([REBUILD_MAN_PAGES], [test x$DOCBOOK2MAN != x])
 AM_CONDITIONAL([GIT_TREE], [test x$GIT != x -a -e .git])
 if test -e .git -a "x$DOCBOOK2MAN" = "x"; then

--- a/drivers/FunctionGeneratorFirmware.h
+++ b/drivers/FunctionGeneratorFirmware.h
@@ -63,6 +63,8 @@ class FunctionGeneratorFirmware : public Owned, public iFunctionGeneratorFirmwar
     FunctionGeneratorFirmware(const ConstructorType& args);
     ~FunctionGeneratorFirmware();
 
+    bool nothing_runs();
+
     std::string                objectPath;
     TimingReceiver             *tr;
     Device&                    device;

--- a/interfaces/ActionSink.xml
+++ b/interfaces/ActionSink.xml
@@ -222,7 +222,7 @@
     -->
   <property name="LateCount" type="t" access="readwrite"/>
   
-  <!-- Late:      An example of a late action since last LateCount change.
+  <!-- Late:      Deprecated! Use SigLate instead.
        @count:    The new value of LateCount when this signal was raised.
        @event:    The event identifier of the late action.
        @param:    The parameter field, whose meaning depends on the event ID.
@@ -241,7 +241,18 @@
     <arg name="deadline" type="t"/>
     <arg name="executed" type="t"/>
   </signal>
+  <!-- Late:      An example of a late action since last LateCount change.
+       @count:    The new value of LateCount when this signal was raised.
+       @event:    The event identifier of the late action.
+       @param:    The parameter field, whose meaning depends on the event ID.
+       @deadline: The desired execution timestamp (event time + offset).
+       @executed: The actual execution timestamp.
 
+       Keep in mind that an action is only counted as late if it is
+       scheduled for the past.  An action which leaves the timing receiver
+       after its deadline, due to a slow consumer, is a delayed (not late)
+       action.
+    -->
   <signal name="SigLate">
     <arg name="count"    type="u"/>
     <arg name="event"    type="t"/>
@@ -264,7 +275,7 @@
     -->
   <property name="EarlyCount" type="t" access="readwrite"/>
   
-  <!-- Early:     An example of an early action since last EarlyCount change.
+  <!-- Early:     Deprecated! Use SigEarly instead.
        @count:    The new value of LateCount when this signal was raised.
        @event:    The event identifier of the early action.
        @param:    The parameter field, whose meaning depends on the event ID.
@@ -278,7 +289,14 @@
     <arg name="deadline" type="t"/>
     <arg name="executed" type="t"/>
   </signal>
-  <signal name="SigEarly">
+  <!-- Early:     An example of an early action since last EarlyCount change.
+       @count:    The new value of LateCount when this signal was raised.
+       @event:    The event identifier of the early action.
+       @param:    The parameter field, whose meaning depends on the event ID.
+       @deadline: The desired execution timestamp (event time + offset).
+       @executed: The actual execution timestamp.
+    -->
+    <signal name="SigEarly">
     <arg name="count"    type="u"/>
     <arg name="event"    type="t"/>
     <arg name="param"    type="t"/>
@@ -298,7 +316,7 @@
     -->
   <property name="ConflictCount" type="t" access="readwrite"/>
   
-  <!-- Conflict:  An example of a conflict since last ConflictCount change.
+  <!-- Conflict:  Deprecated! use SigConflict instead.
        @count:    The new value of ConflictCount when this signal was raised.
        @event:    The event identifier of a conflicting action.
        @param:    The parameter field, whose meaning depends on the event ID.
@@ -312,6 +330,13 @@
     <arg name="deadline" type="t"/>
     <arg name="executed" type="t"/>
   </signal>
+  <!-- Conflict:  An example of a conflict since last ConflictCount change.
+       @count:    The new value of ConflictCount when this signal was raised.
+       @event:    The event identifier of a conflicting action.
+       @param:    The parameter field, whose meaning depends on the event ID.
+       @deadline: The scheduled action execution timestamp (event time + offset).
+       @executed: The timestamp when the action was actually executed.
+    -->  
   <signal name="SigConflict">
     <arg name="count"    type="t"/>
     <arg name="event"    type="t"/>
@@ -334,7 +359,7 @@
     -->
   <property name="DelayedCount" type="t" access="readwrite"/>
   
-  <!-- Delayed:   An example of a delayed action the last DelayedCount change.
+  <!-- Delayed:   Deprecated! Use SigDelayed instead.
        @count:    The value of DelayedCount when this signal was raised.
        @event:    The event identifier of the delayed action.
        @param:    The parameter field, whose meaning depends on the event ID.
@@ -348,6 +373,13 @@
     <arg name="deadline" type="t"/>
     <arg name="executed" type="t"/>
   </signal>
+  <!-- Delayed:   An example of a delayed action the last DelayedCount change.
+       @count:    The value of DelayedCount when this signal was raised.
+       @event:    The event identifier of the delayed action.
+       @param:    The parameter field, whose meaning depends on the event ID.
+       @deadline: The desired execution timestamp (event time + offset).
+       @executed: The timestamp when the action was actually executed.
+    -->
   <signal name="SigDelayed">
     <arg name="count"    type="t"/>
     <arg name="event"    type="t"/>

--- a/interfaces/FunctionGenerator.xml
+++ b/interfaces/FunctionGenerator.xml
@@ -90,7 +90,7 @@
       <arg name="running" type="b"/>
     </signal>
 
-    <!-- Started: Function generation has begun.
+    <!-- Started: Deprecated! use SigStarted instead.
          @time:   Time when function generation began in nanoseconds since 1970
          This signal notifies software when function generation has begun,
          possibly to update a GUI or other user-facing status information.
@@ -98,11 +98,29 @@
     <signal name="Started" deprecated="yes">
       <arg name="time" type="t"/>
     </signal>
+    <!-- SigStarted: Function generation has begun.
+         @time:   Time when function generation began in nanoseconds since 1970
+         This signal notifies software when function generation has begun,
+         possibly to update a GUI or other user-facing status information.
+      -->
     <signal name="SigStarted">
       <arg name="time" type="T"/>
     </signal>
 
-    <!-- Stopped:                   Function generation has ended.
+    <!-- Stopped:                   Deprecated! Use SigStopped instead.
+         @time:                     Time when function generation ended in nanoseconds since 1970
+         @abort:                    stopped due to a call to Abort
+         @hardwareMacroUnderflow:   A fatal error, indicating the SCUbus is congested
+         @microControllerUnderflow: A fatal error, indicating the host CPU is overloaded
+      -->
+    <signal name="Stopped" deprecated="yes">
+      <arg name="time"                     type="t"/>
+      <arg name="aborted"                  type="b"/>
+      <arg name="hardwareMacroUnderflow"   type="b"/>
+      <arg name="microControllerUnderflow" type="b"/>
+    </signal>
+
+    <!-- SigStopped:                   Function generation has ended.
          @time:                     Time when function generation ended in nanoseconds since 1970
          @abort:                    stopped due to a call to Abort
          @hardwareMacroUnderflow:   A fatal error, indicating the SCUbus is congested
@@ -126,13 +144,7 @@
          next time the function generator starts. After stopping, regardless of if the generation
          was successful or not, the parameter FIFO is cleared, Enabled is false, and this signal emitted.
       -->
-    <signal name="Stopped" deprecated="yes">
-      <arg name="time"                     type="t"/>
-      <arg name="aborted"                  type="b"/>
-      <arg name="hardwareMacroUnderflow"   type="b"/>
-      <arg name="microControllerUnderflow" type="b"/>
-    </signal>
-    <signal name="SigStopped">
+      <signal name="SigStopped">
       <arg name="time"                     type="T"/>
       <arg name="aborted"                  type="b"/>
       <arg name="hardwareMacroUnderflow"   type="b"/>

--- a/interfaces/FunctionGeneratorFirmware.xml
+++ b/interfaces/FunctionGeneratorFirmware.xml
@@ -16,7 +16,9 @@
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
     </property>
     
-    <!-- Scan: Scan bus for fg channels.
+    <!-- Scan: Scan bus for fg channels. 
+               This function should only be called if no fg-channel is active.
+               If any channel is active and this function is called a saftbus::Error will be thrown!
          @result:   fgs found.
       -->
     <method name="Scan">

--- a/interfaces/Makefile.am
+++ b/interfaces/Makefile.am
@@ -83,7 +83,9 @@ doc_DATA = 			\
 	Device.pdf		\
 	SAFTd.pdf		\
 	EventSource.pdf		\
+	FunctionGeneratorFirmware.pdf	\
 	FunctionGenerator.pdf	\
+	MasterFunctionGenerator.pdf	\
 	InputEventSource.pdf	\
 	MILbusActionSink.pdf	\
 	MILbusCondition.pdf	\
@@ -97,7 +99,11 @@ doc_DATA = 			\
 	SoftwareActionSink.pdf	\
 	SoftwareCondition.pdf	\
 	TimingReceiver.pdf     \
-	WrMilGateway.pdf
+	WrMilGateway.pdf     \
+	Types.pdf
+
+Types.pdf: Types.texi
+	$(TEXI2PDF) Types.texi
 endif
 
 libsaftlib_la_LIBADD = $(SIGCPP_LIBS)
@@ -153,9 +159,11 @@ $(doc_DATA:.pdf=.doc-xml) $(nodist_libsaftlib_la_SOURCES) $(nodist_saftlib_HEADE
 	$(XSLTPROC) --path $(srcdir) --xinclude $(srcdir)/doc.xsl $(NODES)
 
 .doc-xml.pdf:
-	rm -f docfoo-*.$*.*
+	rm -f docfoo-*.$*.* 
 	$(GDBUS_CODEGEN) --generate-docbook=docfoo --interface-prefix=de.gsi.saftlib $<
-	$(XSLTPROC) --path $(srcdir) fix-docbook.xsl docfoo-*.$*.xml > docfoo-fix.$*.xml
-	$(DOCBOOK2PDF) docfoo-fix.$*.xml
+	$(XSLTPROC) --path $(srcdir) fix-docbook.xsl docfoo-de.gsi.saftlib.$*.xml > docfoo-fix.$*.xml
+	$(DOCBOOK2TEXI) --string-param output-file=docfoo-fix.$* docfoo-fix.$*.xml
+	$(TEXI2PDF) docfoo-fix.$*.texi	
 	mv docfoo-*.$*.pdf $@
-	rm -f docfoo-*.$*.*
+	rm -f docfoo-de.gsi.saftlib.$*.xml docfoo-fix.$*.* 
+

--- a/interfaces/Makefile.am
+++ b/interfaces/Makefile.am
@@ -103,7 +103,7 @@ doc_DATA = 			\
 	Types.pdf
 
 Types.pdf: Types.texi
-	$(TEXI2PDF) Types.texi
+	$(TEXI2PDF) Types.texi; rm Types.aux Types.log Types.toc
 endif
 
 libsaftlib_la_LIBADD = $(SIGCPP_LIBS)

--- a/interfaces/MasterFunctionGenerator.xml
+++ b/interfaces/MasterFunctionGenerator.xml
@@ -80,7 +80,7 @@
 
          Parameters are sent as a vector of vectors. 
          The outside vectors contain a coefficient vector for each FG and must be of the same size
-         and <= the number of active FGs.
+         and less or equal the number of active FGs.
          The coefficient vectors for each FG's parameter set must be the same size
          but different FGs may have different parameter set sizes. 
          If there is no data for an individual function generator an empty vector 
@@ -131,7 +131,21 @@
     <method name="Flush"/>
 
 
-    <!-- Stopped: Stopped signal forwarded from a single Function Generator
+    <!-- Stopped: Deprecated! Use SigStopped instead.
+         @name:                     Name of the FG that generated the signal.
+         @time:                     Time when function generation ended in nanoseconds since 1970
+         @abort:                    stopped due to a call to Abort
+         @hardwareMacroUnderflow:   A fatal error, indicating the SCUbus is congested
+         @microControllerUnderflow: A fatal error, indicating the host CPU is overloaded
+      -->
+    <signal name="Stopped" deprecated="yes">
+      <arg name="name"                     type="s"/>
+      <arg name="time"                     type="t"/>
+      <arg name="aborted"                  type="b"/>
+      <arg name="hardwareMacroUnderflow"   type="b"/>
+      <arg name="microControllerUnderflow" type="b"/>
+    </signal>
+    <!-- SigStopped: Stopped signal forwarded from a single Function Generator
          @name:                     Name of the FG that generated the signal.
          @time:                     Time when function generation ended in nanoseconds since 1970
          @abort:                    stopped due to a call to Abort
@@ -156,13 +170,6 @@
          next time the function generator starts. After stopping, regardless of if the generation
          was successful or not, the parameter FIFO is cleared, Enabled is false, and this signal emitted.
       -->
-    <signal name="Stopped" deprecated="yes">
-      <arg name="name"                     type="s"/>
-      <arg name="time"                     type="t"/>
-      <arg name="aborted"                  type="b"/>
-      <arg name="hardwareMacroUnderflow"   type="b"/>
-      <arg name="microControllerUnderflow" type="b"/>
-    </signal>
     <signal name="SigStopped">
       <arg name="name"                     type="s"/>
       <arg name="time"                     type="T"/>
@@ -193,12 +200,14 @@
       <arg name="running"                  type="b"/>
     </signal>
 
-    <!-- Started: Started signal forwarded from a single Function Generator
+    <!-- Started: Deprecated! Use SigStarted instead.
          -->
     <signal name="Started" deprecated="yes">
       <arg name="name"                     type="s"/>
       <arg name="time"                     type="t"/>
     </signal>
+    <!-- SigStarted: Started signal forwarded from a single Function Generator
+         -->
     <signal name="SigStarted">
       <arg name="name"                     type="s"/>
       <arg name="time"                     type="T"/>
@@ -210,16 +219,21 @@
       <arg name="name"                     type="s"/>
     </signal>
 
-    <!-- AllStopped:                All Function generators have stopped.
+    <!-- AllStopped:                Deprecated! Use SigAllStopped instead.
          @time:                     Time when last function generation ended in nanoseconds since 1970
 
          This signal is generated when a function generator stops and all function generators
          controlled by this master have then stopped. 
     -->
-
     <signal name="AllStopped" deprecated="yes">
       <arg name="time" type="t"/>
     </signal>
+    <!-- SigAllStopped:                All Function generators have stopped.
+         @time:                     Time when last function generation ended
+
+         This signal is generated when a function generator stops and all function generators
+         controlled by this master have then stopped. 
+    -->
     <signal name="SigAllStopped">
       <arg name="time" type="T"/>
     </signal>

--- a/interfaces/SoftwareCondition.xml
+++ b/interfaces/SoftwareCondition.xml
@@ -13,7 +13,21 @@
        that the object also implements the general Condition interface.
     -->
   <interface name="de.gsi.saftlib.SoftwareCondition">
-    <!-- Action:    Emitted whenever the condition matches a timing event.
+    <!-- Action:    Deprecated! Use SigAction instead.
+         @event:    The event identifier that matched this rule.
+         @param:    The parameter field, whose meaning depends on the event ID.
+         @deadline: The scheduled execution timestamp of the action (event time + offset).
+         @executed: The actual execution timestamp of the action.
+         @flags:    Whether the action was (ok=0,late=1,early=2,conflict=4,delayed=8)
+      -->
+    <signal name="Action" deprecated="yes">
+      <arg name="event"    type="t"/>
+      <arg name="param"    type="t"/>
+      <arg name="deadline" type="t"/>
+      <arg name="executed" type="t"/>
+      <arg name="flags"    type="q"/>
+    </signal>
+    <!-- SigAction:    Emitted whenever the condition matches a timing event.
          @event:    The event identifier that matched this rule.
          @param:    The parameter field, whose meaning depends on the event ID.
          @deadline: The scheduled execution timestamp of the action (event time + offset).
@@ -30,14 +44,7 @@
          Actions with error flags (late, early, conflict, delayed) are only
          delivered to this signal if the Condition which generated them
          specified that the respective error should be accepted.
-      -->
-    <signal name="Action" deprecated="yes">
-      <arg name="event"    type="t"/>
-      <arg name="param"    type="t"/>
-      <arg name="deadline" type="t"/>
-      <arg name="executed" type="t"/>
-      <arg name="flags"    type="q"/>
-    </signal>
+      -->    
     <signal name="SigAction">
       <arg name="event"    type="t"/>
       <arg name="param"    type="t"/>

--- a/interfaces/TimingReceiver.xml
+++ b/interfaces/TimingReceiver.xml
@@ -70,14 +70,23 @@
       <arg  direction="out" type="i" name="result"/>
     </method>
 
-    <!-- ReadCurrentTime: The current time in nanoseconds since 1970.
+    <!-- ReadCurrentTime: This method is deprecaded, use CurrentTime instead. 
          @result:         Nanoseconds since 1970.
+         The current time in nanoseconds since 1970.
          Due to delays in software, the returned value is probably several
          milliseconds behind the true time.
       -->
     <method name="ReadCurrentTime" deprecated="yes">
       <arg direction="out" type="t" name="result"/>
     </method>
+    <!-- CurrentTime: The current time of the timingreceiver.
+         @result:     the current time of the timingreceiver
+         The result type is saftlib::Time, which can be used to obtain 
+         either the number of nanoseconds since 1970, or the same value
+         minus the current UTC offset.
+         Due to delays in software, the returned value is probably several
+         milliseconds behind the true time.
+      -->
     <method name="CurrentTime">
       <arg direction="out" type="T" name="result"/>
     </method>
@@ -128,11 +137,12 @@
       -->
     <property name="Interfaces" type="a{sa{ss}}" access="read"/>
     
-    <!-- InjectEvent: Simulate the receipt of a timing event.
+    <!-- InjectEvent: The method is depricated, use InjectEvent with saftlib::Time instead.
          @event: The event identifier which is matched against Conditions
          @param: The parameter field, whose meaning depends on the event ID.
          @time:  The execution time for the event, added to condition offsets.
          
+         Simulate the receipt of a timing event
          Sometimes it is useful to simulate the receipt of a timing event. 
          This allows software to test that configured conditions lead to the
          desired behaviour without needing the data master to send anything.
@@ -142,6 +152,16 @@
       <arg direction="in" type="t" name="param"/>
       <arg direction="in" type="t" name="time"/>
     </method>
+    <!-- InjectEvent: Simulate the receipt of a timing event
+
+         @event: The event identifier which is matched against Conditions
+         @param: The parameter field, whose meaning depends on the event ID.
+         @time:  The execution time for the event, added to condition offsets.
+         
+         Sometimes it is useful to simulate the receipt of a timing event. 
+         This allows software to test that configured conditions lead to the
+         desired behaviour without needing the data master to send anything.
+      -->
     <method name="InjectEvent">
       <arg direction="in" type="t" name="event"/>
       <arg direction="in" type="t" name="param"/>

--- a/interfaces/Types.texi
+++ b/interfaces/Types.texi
@@ -10,7 +10,7 @@
 @top Saftlib
 @chapheading Types
 
-The saftlib interfaces documentation uses a number of types which are character encoded. Because Saftlib used DBus in the past, the encoding is similar but not identical to the DBus type encoding. Here is a list of types and its representation in C++ API:
+The saftlib interfaces documentation uses a number of types which are character encoded. Because Saftlib used DBus in the past, the encoding is similar but not identical to the DBus type encoding. The following table lists all types and their representation in the C++ API:
 
 @example 
 y        uint8_t

--- a/interfaces/Types.texi
+++ b/interfaces/Types.texi
@@ -1,0 +1,30 @@
+\input texinfo
+@setfilename Types.info
+@documentencoding us-ascii
+@settitle Saftlib
+@direntry
+* Saftlib: (Types).   Types used in Saftlib interfaces.
+@end direntry
+
+@node Top
+@top Saftlib
+@chapheading Types
+
+The saftlib interfaces documentation uses a number of types which are character encoded. Because Saftlib used DBus in the past, the encoding is similar but not identical to the DBus type encoding. Here is a list of types and its representation in C++ API:
+
+@example 
+y        uint8_t
+b        bool
+n        int16_t
+q        uint16_t
+i        int32_t
+u        uint32_t
+x        int64_t
+t        uint64_t
+d        double
+T        saftlib::Time
+s        std::string
+aX       std::vector<X> where X is can be any type
+a@{KV@}    std::map<K,V> K and V are are key and value types
+
+@bye

--- a/interfaces/WrMilGateway.xml
+++ b/interfaces/WrMilGateway.xml
@@ -4,123 +4,149 @@
   <!-- Include base interfaces -->
   <xi:include href="Owned.xml"/>
   
+  <!-- de.gsi.saftlib.WrMilGateway:
+       @short_description: A converter for WhiteRabbit timing events to MIL.
+     
+       The WhiteRabbit-MIL-Gateway receives WhiteRabbit timing events, translates
+       them into MIL timing events and outputs them with few microsecond accuracy.
+       This device is needed to run SIS18 and ESR.
+    -->  
   <interface name="de.gsi.saftlib.WrMilGateway">
     
-    <!-- Access all registers of the WrMilGateway -->
+    <!-- RegisterContent: Access all registers of the WrMilGateway -->
     <property name="RegisterContent"   type="au" access="read">
     </property>
 
-    <!-- Access MIL event histogram WrMilGateway -->
+    <!-- MilHistogram: Access MIL event histogram WrMilGateway -->
     <property name="MilHistogram"   type="au" access="read">
     </property>
 
-    <!-- WR-MIL magic number -->
+    <!-- WrMilMagic: WR-MIL magic number -->
     <property name="WrMilMagic"   type="u" access="read">
     </property>
 
-    <!-- WR-MIL firmware state -->
+    <!-- FirmwareState: WR-MIL firmware state -->
     <property name="FirmwareState"   type="u" access="read">
     </property>
-    <!-- signal emitted if firmware state changes -->
+    <!-- SigFirmwareState: signal emitted if firmware state changes -->
     <signal name="SigFirmwareState">
       <arg name="state" type="u"/>
     </signal>
 
-    <!-- WR-MIL firmware is active (not stalled) -->
+    <!-- FirmwareRunning: WR-MIL firmware is active (not stalled) -->
     <property name="FirmwareRunning"   type="b" access="read">
     </property>
 
-    <!-- signal emitted if starts/stops running -->
+    <!-- SigFirmwareRunning: signal emitted if starts/stops running -->
     <signal name="SigFirmwareRunning">
       <arg name="running" type="b"/>
     </signal>
 
-    <!-- WR-MIL event source. This can be either 
+    <!-- EventSource: WR-MIL event source. 
+
+         This can be: 
+
          0 -> not configured (default)
+
          1 -> SIS18 (work as SIS18 "Pulszentrale")
+
          2 -> ESR   (work as ESR "Pulszentrale")   -->
     <property name="EventSource"   type="u" access="read">
     </property>
-    <!-- signal emitted if event source changes -->
+    <!-- SigEventSource: signal emitted if event source changes -->
     <signal name="SigEventSource">
       <arg name="source" type="u"/>
     </signal>
 
 
-    <!-- The event number that triggers generation of UTC events -->
+    <!-- UtcTrigger: The event number that triggers generation of UTC events -->
     <property name="UtcTrigger"   type="y" access="readwrite">
     </property>
 
-    <!-- event latency in microseconds. This is the time between the 
-         WR-event deadline and the rising edge at the TIF module caused
-         by the translated MIL event -->
+    <!-- EventLatency: Event latency in microseconds. 
+
+         This is the time between the WR-event deadline and the 
+         rising edge at the TIF module caused by the translated 
+         MIL event -->
     <property name="EventLatency"   type="u" access="readwrite">
     </property>
 
-    <!-- Time between the generated UTC MIL events -->
+    <!-- UtcUtcDelay: Time between the generated UTC MIL events -->
     <property name="UtcUtcDelay"   type="u" access="readwrite">
     </property>
 
-    <!-- Time between the UTC trigger event and the first UTC MIL event -->
+    <!-- TriggerUtcDelay: Time between the UTC trigger event and the first UTC MIL event -->
     <property name="TriggerUtcDelay"   type="u" access="readwrite">
     </property>
 
-    <!-- The number of seconds that is added to the WR-TAI 
+    <!-- UtcOffset: seconds between 01.01.2008 and 01.01.1970
+
+         The number of seconds that is added to the WR-TAI 
          (which starts at 1970) to create a UTC time that  
          starts at 2008 (64bit value) -->
     <property name="UtcOffset"   type="t" access="readwrite">
     </property>
 
 
-    <!-- The number of translated events (as 64bit value) -->
+    <!-- NumMilEvents: The number of translated events (as 64bit value) -->
     <property name="NumMilEvents"   type="t" access="read">
     </property>
 
-    <!-- read a histogram of event delays 
-          [0]: delay < 2^10 ns
-          [1]: delay < 2^11 ns
-          [2]: delay < 2^12 ns
+    <!-- LateHistogram: read a histogram of event delays 
+
+        Bin content:
+
+          [0]: delay less than 2^10 ns
+
+          [1]: delay less than 2^11 ns
+
+          [2]: delay less than 2^12 ns
+
          ...
-         [14]: delay < 2^24 ns
-         [15]: delay < 2^25 ns
+
+         [14]: delay less than 2^24 ns
+
+         [15]: delay less than 2^25 ns
+
     -->
     <property name="LateHistogram"   type="au" access="read">
     </property>
 
 
-    <!-- The number of translated events that were submitted later  
+    <!-- NumLateMilEvents: The number of translated events that were submitted later  
          than the anticipated WR event deadline -->
     <property name="NumLateMilEvents"   type="u" access="read">
     </property>
-    <!-- signal emitted if number of late events increases -->
+    <!-- SigNumLateMilEvents: signal emitted if number of late events increases -->
     <signal name="SigNumLateMilEvents">
       <arg name="total" type="u"/>
       <arg name="since_last_signal" type="u"/>
     </signal>
 
 
+    <!-- InUse: indicates if the gateway is translating any events -->
     <property name="InUse"   type="b" access="read">
     </property>
-    <!-- signal emitted if number of late events increases -->
+    <!-- SigInUse: signal emitted if number of events increases -->
     <signal name="SigInUse">
       <arg name="inUse" type="b"/>
     </signal>
 
 
 
-    <!-- Configure Gateway as SIS18 "Pulszentrale" and start -->
+    <!-- StartSIS18: Configure Gateway as SIS18 "Pulszentrale" and start -->
     <method name="StartSIS18"/>
 
-    <!-- Configure Gateway as ESR "Pulszentrale" and start -->
+    <!-- StartESR: Configure Gateway as ESR "Pulszentrale" and start -->
     <method name="StartESR"/>
 
-    <!-- Reset all event counters and histograms -->
+    <!-- ClearStatistics: Reset all event counters and histograms -->
     <method name="ClearStatistics"/>
 
-    <!-- Stop WR-MIL Gateway and restart after 1 second pause -->
+    <!-- ResetGateway: Stop WR-MIL Gateway and restart after 1 second pause -->
     <method name="ResetGateway"/>
 
-    <!-- Kill WR-MIL Gateway. Only MCU reset can recover (useful to 
+    <!-- KillGateway: Kill WR-MIL Gateway. Only MCU reset can recover (useful to 
          do before loading new firmware)-->
     <method name="KillGateway"/>
 

--- a/saftcommon/Time.h
+++ b/saftcommon/Time.h
@@ -181,7 +181,7 @@ namespace saftlib
 			return TAI_is_UTCleap(TAI);
 		}
 
-		friend Time makeTimeUTC(uint64_t UTC, bool isLeap = false);
+		friend Time makeTimeUTC(uint64_t UTC, bool isLeap);
 		friend Time makeTimeTAI(uint64_t TAI);
 	private:
 		explicit Time(const uint64_t& value) : TAI(value) {
@@ -194,7 +194,7 @@ namespace saftlib
 	Time operator-(const Time& lhs, const int64_t& rhs);
 	Time operator+(const int64_t& lhs, const Time& rhs);
 	Time operator-(const int64_t& lhs, const Time& rhs);
-	Time makeTimeUTC(uint64_t UTC, bool isLeap);
+	Time makeTimeUTC(uint64_t UTC, bool isLeap = false);
 	Time makeTimeTAI(uint64_t TAI);
 
 


### PR DESCRIPTION
Safe re-scanning for function generator channels. 
Before saftd would crash if any fg channels were running when FunctionGeneratorFirmware::Scan() was called. 
Now an exception (saftbus::Error) is thrown and no re-scanning is done. 

This branch also contains fixes for pdf documentation generation.
