### PR TITLE
Safe rescan of FunctionGenerator channels

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Set these variables before each release:
 m4_define(MAJOR,2)    dnl Increment if removed/changed properties/signals/methods since previous release
-m4_define(MINOR,0)    dnl Increment if added properties/signals/methods; reset to 0 if MAJOR changed
+m4_define(MINOR,1)    dnl Increment if added properties/signals/methods; reset to 0 if MAJOR changed
 m4_define(REVISION,0) dnl Increment on each release; reset to 0 if MAJOR/MINOR changed
 m4_define(SONAME,4)   dnl Whenever MAJOR is incremented, add MINOR+1 to this variable
 

--- a/configure.ac
+++ b/configure.ac
@@ -58,12 +58,19 @@ if test "x$XSLTPROC" = "x"; then
 fi
 
 dnl Generate documentation, only if we can
-AC_PATH_PROGS([DOCBOOK2PDF], [docbook2pdf])
+AC_PATH_PROGS([DOCBOOK2TEXI], [docbook2texi])
+AC_PATH_PROGS([TEXI2PDF], [texi2pdf])
+AC_PATH_PROGS([GDBUS_CODEGEN], [gdbus-codegen])
 AC_PATH_PROGS([DOCBOOK2MAN], [docbook2man])
 AC_PATH_PROGS([GIT], [git])
 
+AC_ARG_ENABLE([pdf-doc], 
+              [AS_HELP_STRING([--enable-pdf-doc], [generate pdf documentation of interfaces])], 
+              [ENABLE_PDF_DOC=yes], 
+              []
+             )
 
-AM_CONDITIONAL([INTERFACE_DOCS], [test x$DOCBOOK2PDF != x -a x$GDBUS_CODEGEN != x])
+AM_CONDITIONAL([INTERFACE_DOCS], [test x$ENABLE_PDF_DOC != x -a x$DOCBOOK2TEXI != x -a x$TEXI2PDF != x -a x$GDBUS_CODEGEN != x])
 AM_CONDITIONAL([REBUILD_MAN_PAGES], [test x$DOCBOOK2MAN != x])
 AM_CONDITIONAL([GIT_TREE], [test x$GIT != x -a -e .git])
 if test -e .git -a "x$DOCBOOK2MAN" = "x"; then

--- a/drivers/ActionSink.cpp
+++ b/drivers/ActionSink.cpp
@@ -97,8 +97,8 @@ void ActionSink::ToggleActive()
   }
 
   // notify changes
-  for (i = conditions.begin(); i != conditions.end(); ++i)
-    i->second->Active(i->second->getActive());
+  // for (i = conditions.begin(); i != conditions.end(); ++i)
+  //   i->second->Active(i->second->getActive());
   notify(true, true);
 }
 
@@ -203,14 +203,14 @@ void ActionSink::setMinOffset(int64_t val)
 {
   ownerOnly();
   minOffset = val;
-  MinOffset(minOffset);
+  //MinOffset(minOffset);
 }
 
 void ActionSink::setMaxOffset(int64_t val)
 {
   ownerOnly();
   maxOffset = val;
-  MaxOffset(maxOffset);
+  //MaxOffset(maxOffset);
 }
 
 void ActionSink::setMostFull(uint16_t val)
@@ -224,7 +224,7 @@ void ActionSink::setSignalRate(uint64_t val)
 {
   ownerOnly();
   signalRate = val;
-  SignalRate(signalRate);
+  //SignalRate(signalRate);
 }
 
 void ActionSink::setOverflowCount(uint64_t val)
@@ -232,7 +232,7 @@ void ActionSink::setOverflowCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set OverflowCount to 0");
   overflowCount = 0;
-  OverflowCount(overflowCount);
+  //OverflowCount(overflowCount);
 }
 
 void ActionSink::setActionCount(uint64_t val)
@@ -240,7 +240,7 @@ void ActionSink::setActionCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set ActionCount to 0");
   actionCount = 0;
-  ActionCount(actionCount);
+  //ActionCount(actionCount);
 }
 
 void ActionSink::setLateCount(uint64_t val)
@@ -248,7 +248,7 @@ void ActionSink::setLateCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set LateCount to 0");
   lateCount = 0;
-  LateCount(lateCount);
+  //LateCount(lateCount);
 }
 
 void ActionSink::setEarlyCount(uint64_t val)
@@ -256,7 +256,7 @@ void ActionSink::setEarlyCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set EarlyCount to 0");
   earlyCount = 0;
-  EarlyCount(earlyCount);
+  //EarlyCount(earlyCount);
 }
 
 void ActionSink::setConflictCount(uint64_t val)
@@ -264,7 +264,7 @@ void ActionSink::setConflictCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set ConflictCount to 0");
   conflictCount = 0;
-  ConflictCount(conflictCount);
+  //ConflictCount(conflictCount);
 }
 
 void ActionSink::setDelayedCount(uint64_t val)
@@ -272,7 +272,7 @@ void ActionSink::setDelayedCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set DelayedCount to 0");
   delayedCount = 0;
-  DelayedCount(delayedCount);
+  //DelayedCount(delayedCount);
 }
 
 void ActionSink::receiveMSI(uint8_t code)
@@ -368,7 +368,7 @@ bool ActionSink::updateOverflow(uint64_t time)
 
   overflowCount += overflow;
   overflowUpdate = time;
-  OverflowCount(overflowCount);
+  //OverflowCount(overflowCount);
   return false;
 }
 
@@ -388,7 +388,7 @@ bool ActionSink::updateAction(uint64_t time)
 
   actionCount += valid;
   actionUpdate = time;
-  ActionCount(actionCount);
+  //ActionCount(actionCount);
   return false;
 }
 
@@ -432,7 +432,7 @@ bool ActionSink::updateLate(uint64_t time)
   if (!r.count) clog << kLogErr << "Received LATE MSI, but FAILED_COUNT was 0" << std::endl;
   lateCount += r.count;
   lateUpdate = time;
-  LateCount(lateCount);
+  //LateCount(lateCount);
   Late(lateCount, r.event, r.param, r.deadline, r.executed);
   SigLate(lateCount, r.event, r.param, saftlib::makeTimeTAI(r.deadline), saftlib::makeTimeTAI(r.executed));
   return false;
@@ -444,7 +444,7 @@ bool ActionSink::updateEarly(uint64_t time)
   if (!r.count) clog << kLogErr << "Received EARLY MSI, but FAILED_COUNT was 0" << std::endl;
   earlyCount += r.count;
   earlyUpdate = time;
-  EarlyCount(earlyCount);
+  //EarlyCount(earlyCount);
   Early(earlyCount, r.event, r.param, r.deadline, r.executed);
   SigEarly(earlyCount, r.event, r.param, saftlib::makeTimeTAI(r.deadline), saftlib::makeTimeTAI(r.executed));
   return false;
@@ -456,7 +456,7 @@ bool ActionSink::updateConflict(uint64_t time)
   if (!r.count) clog << kLogErr << "Received CONFLICT MSI, but FAILED_COUNT was 0" << std::endl;
   conflictCount += r.count;
   conflictUpdate = time;
-  ConflictCount(conflictCount);
+  //ConflictCount(conflictCount);
   Conflict(conflictCount, r.event, r.param, r.deadline, r.executed);
   SigConflict(conflictCount, r.event, r.param, saftlib::makeTimeTAI(r.deadline), saftlib::makeTimeTAI(r.executed));
   return false;
@@ -468,7 +468,7 @@ bool ActionSink::updateDelayed(uint64_t time)
   if (!r.count) clog << kLogErr << "Received DELAYED MSI, but FAILED_COUNT was 0" << std::endl;
   delayedCount += r.count;
   delayedUpdate = time;
-  DelayedCount(delayedCount);
+  //DelayedCount(delayedCount);
   Delayed(delayedCount, r.event, r.param, r.deadline, r.executed);
   SigDelayed(delayedCount, r.event, r.param, saftlib::makeTimeTAI(r.deadline), saftlib::makeTimeTAI(r.executed));
   return false;
@@ -488,9 +488,9 @@ void ActionSink::removeCondition(Conditions::iterator i)
 
 void ActionSink::notify(bool active, bool inactive)
 {
-  AllConditions(getAllConditions());
-  if (active)   ActiveConditions(getActiveConditions());
-  if (inactive) InactiveConditions(getInactiveConditions());
+  // AllConditions(getAllConditions());
+  // if (active)   ActiveConditions(getActiveConditions());
+  // if (inactive) InactiveConditions(getInactiveConditions());
 }
 
 void ActionSink::compile()

--- a/drivers/ActionSink.cpp
+++ b/drivers/ActionSink.cpp
@@ -95,11 +95,6 @@ void ActionSink::ToggleActive()
       i->second->setRawActive(!i->second->getActive());
     throw;
   }
-
-  // notify changes
-  // for (i = conditions.begin(); i != conditions.end(); ++i)
-  //   i->second->Active(i->second->getActive());
-  notify(true, true);
 }
 
 uint16_t ActionSink::ReadFill()
@@ -203,14 +198,12 @@ void ActionSink::setMinOffset(int64_t val)
 {
   ownerOnly();
   minOffset = val;
-  //MinOffset(minOffset);
 }
 
 void ActionSink::setMaxOffset(int64_t val)
 {
   ownerOnly();
   maxOffset = val;
-  //MaxOffset(maxOffset);
 }
 
 void ActionSink::setMostFull(uint16_t val)
@@ -224,7 +217,6 @@ void ActionSink::setSignalRate(uint64_t val)
 {
   ownerOnly();
   signalRate = val;
-  //SignalRate(signalRate);
 }
 
 void ActionSink::setOverflowCount(uint64_t val)
@@ -232,7 +224,6 @@ void ActionSink::setOverflowCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set OverflowCount to 0");
   overflowCount = 0;
-  //OverflowCount(overflowCount);
 }
 
 void ActionSink::setActionCount(uint64_t val)
@@ -240,7 +231,6 @@ void ActionSink::setActionCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set ActionCount to 0");
   actionCount = 0;
-  //ActionCount(actionCount);
 }
 
 void ActionSink::setLateCount(uint64_t val)
@@ -248,7 +238,6 @@ void ActionSink::setLateCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set LateCount to 0");
   lateCount = 0;
-  //LateCount(lateCount);
 }
 
 void ActionSink::setEarlyCount(uint64_t val)
@@ -256,7 +245,6 @@ void ActionSink::setEarlyCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set EarlyCount to 0");
   earlyCount = 0;
-  //EarlyCount(earlyCount);
 }
 
 void ActionSink::setConflictCount(uint64_t val)
@@ -264,7 +252,6 @@ void ActionSink::setConflictCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set ConflictCount to 0");
   conflictCount = 0;
-  //ConflictCount(conflictCount);
 }
 
 void ActionSink::setDelayedCount(uint64_t val)
@@ -272,7 +259,6 @@ void ActionSink::setDelayedCount(uint64_t val)
   ownerOnly();
   if (val != 0) throw saftbus::Error(saftbus::Error::INVALID_ARGS, "can only set DelayedCount to 0");
   delayedCount = 0;
-  //DelayedCount(delayedCount);
 }
 
 void ActionSink::receiveMSI(uint8_t code)
@@ -368,7 +354,6 @@ bool ActionSink::updateOverflow(uint64_t time)
 
   overflowCount += overflow;
   overflowUpdate = time;
-  //OverflowCount(overflowCount);
   return false;
 }
 
@@ -388,7 +373,6 @@ bool ActionSink::updateAction(uint64_t time)
 
   actionCount += valid;
   actionUpdate = time;
-  //ActionCount(actionCount);
   return false;
 }
 
@@ -432,7 +416,6 @@ bool ActionSink::updateLate(uint64_t time)
   if (!r.count) clog << kLogErr << "Received LATE MSI, but FAILED_COUNT was 0" << std::endl;
   lateCount += r.count;
   lateUpdate = time;
-  //LateCount(lateCount);
   Late(lateCount, r.event, r.param, r.deadline, r.executed);
   SigLate(lateCount, r.event, r.param, saftlib::makeTimeTAI(r.deadline), saftlib::makeTimeTAI(r.executed));
   return false;
@@ -444,7 +427,6 @@ bool ActionSink::updateEarly(uint64_t time)
   if (!r.count) clog << kLogErr << "Received EARLY MSI, but FAILED_COUNT was 0" << std::endl;
   earlyCount += r.count;
   earlyUpdate = time;
-  //EarlyCount(earlyCount);
   Early(earlyCount, r.event, r.param, r.deadline, r.executed);
   SigEarly(earlyCount, r.event, r.param, saftlib::makeTimeTAI(r.deadline), saftlib::makeTimeTAI(r.executed));
   return false;
@@ -456,7 +438,6 @@ bool ActionSink::updateConflict(uint64_t time)
   if (!r.count) clog << kLogErr << "Received CONFLICT MSI, but FAILED_COUNT was 0" << std::endl;
   conflictCount += r.count;
   conflictUpdate = time;
-  //ConflictCount(conflictCount);
   Conflict(conflictCount, r.event, r.param, r.deadline, r.executed);
   SigConflict(conflictCount, r.event, r.param, saftlib::makeTimeTAI(r.deadline), saftlib::makeTimeTAI(r.executed));
   return false;
@@ -468,7 +449,6 @@ bool ActionSink::updateDelayed(uint64_t time)
   if (!r.count) clog << kLogErr << "Received DELAYED MSI, but FAILED_COUNT was 0" << std::endl;
   delayedCount += r.count;
   delayedUpdate = time;
-  //DelayedCount(delayedCount);
   Delayed(delayedCount, r.event, r.param, r.deadline, r.executed);
   SigDelayed(delayedCount, r.event, r.param, saftlib::makeTimeTAI(r.deadline), saftlib::makeTimeTAI(r.executed));
   return false;
@@ -479,18 +459,10 @@ void ActionSink::removeCondition(Conditions::iterator i)
   bool active = i->second->getActive();
   conditions.erase(i);
   try {
-    notify(active, !active);
     if (active) dev->compile();
   } catch (...) {
     clog << kLogErr << "Failed to recompile after removing condition (should be impossible)" << std::endl;
   }
-}
-
-void ActionSink::notify(bool active, bool inactive)
-{
-  // AllConditions(getAllConditions());
-  // if (active)   ActiveConditions(getActiveConditions());
-  // if (inactive) InactiveConditions(getInactiveConditions());
 }
 
 void ActionSink::compile()
@@ -537,7 +509,6 @@ std::string ActionSink::NewConditionHelper(bool active, uint64_t id, uint64_t ma
     throw;
   }
 
-  notify(active, !active);
   return condition->getObjectPath();
 }
 

--- a/drivers/ActionSink.h
+++ b/drivers/ActionSink.h
@@ -65,32 +65,10 @@ class ActionSink : public Owned, public iActionSink
     void setConflictCount(uint64_t val);
     void setDelayedCount(uint64_t val);
     
-    // These property signals are available from base classes
-    //   sigc::signal< void, const std::vector< std::string >& > AllConditions;
-    //   sigc::signal< void, const std::vector< std::string >& > ActiveConditions;
-    //   sigc::signal< void, const std::vector< std::string >& > InactiveConditions;
-    //   sigc::signal< void, int64_t > MinOffset;
-    //   sigc::signal< void, int64_t > MaxOffset;
-    //   sigc::signal< void, uint16_t > MostFull;
-    //   sigc::signal< void, uint64_t > SignalRate;
-    //   sigc::signal< void, uint64_t > OverflowCount;
-    //   sigc::signal< void, uint64_t > ActionCount;
-    //   sigc::signal< void, uint64_t > LateCount;
-    //   sigc::signal< void, uint64_t > EarlyCount;
-    //   sigc::signal< void, uint64_t > ConflictCount;
-    //   sigc::signal< void, uint64_t > DelayedCount;
-    // These signals are available from base classes
-    //   sigc::signal< void , uint32_t , uint64_t , uint64_t , uint64_t , uint64_t > Late;
-    //   sigc::signal< void , uint32_t , uint64_t , uint64_t , uint64_t , uint64_t > Early;
-    //   sigc::signal< void , uint64_t , uint64_t , uint64_t , uint64_t , uint64_t > Conflict;
-    //   sigc::signal< void , uint64_t , uint64_t , uint64_t , uint64_t , uint64_t > Delayed;
-
     // Do the grunt work to create a condition
     typedef sigc::slot<std::shared_ptr<Condition>, const Condition::Condition_ConstructorType&> ConditionConstructor;
     std::string NewConditionHelper(bool active, uint64_t id, uint64_t mask, int64_t offset, uint32_t tag, bool tagIsKey, ConditionConstructor constructor);
 
-    // Emit AllConditions, ActiveConditions, InactiveConditions
-    void notify(bool active = true, bool inactive = true);
     void compile();
     
     // The name under which this ActionSink is listed in TimingReceiver::Iterfaces

--- a/drivers/Condition.cpp
+++ b/drivers/Condition.cpp
@@ -85,7 +85,7 @@ void Condition::setID(uint64_t val)
   id = val;
   try {
     if (active) sink->compile();
-    ID(id);
+    //ID(id);
   } catch (...) {
     id = old;
     throw;
@@ -101,7 +101,7 @@ void Condition::setMask(uint64_t val)
   mask = val;
   try {
     if (active) sink->compile();
-    Mask(mask);
+    //Mask(mask);
   } catch (...) {
     mask = old;
     throw;
@@ -117,7 +117,7 @@ void Condition::setOffset(int64_t val)
   offset = val;
   try {
     if (active) sink->compile();
-    Offset(offset);
+    //Offset(offset);
   } catch (...) {
     offset = old;
     throw;
@@ -132,7 +132,7 @@ void Condition::setAcceptLate(bool val)
   acceptLate = val;
   try {
     if (active) sink->compile();
-    AcceptLate(val);
+    //AcceptLate(val);
   } catch (...) {
     acceptLate = !val;
     throw;
@@ -148,7 +148,7 @@ void Condition::setAcceptEarly(bool val)
   acceptEarly = val;
   try {
     if (active) sink->compile();
-    AcceptEarly(val);
+    //AcceptEarly(val);
   } catch (...) {
     acceptEarly = !val;
     throw;
@@ -163,7 +163,7 @@ void Condition::setAcceptConflict(bool val)
   acceptConflict = val;
   try {
     if (active) sink->compile();
-    AcceptConflict(val);
+    //AcceptConflict(val);
   } catch (...) {
     acceptConflict = !val;
     throw;
@@ -178,7 +178,7 @@ void Condition::setAcceptDelayed(bool val)
   acceptDelayed = val;
   try {
     if (active) sink->compile();
-    AcceptDelayed(val);
+    //AcceptDelayed(val);
   } catch (...) {
     acceptDelayed = !val;
     throw;
@@ -193,7 +193,7 @@ void Condition::setActive(bool val)
   active = val;
   try {
     sink->compile();
-    Active(active);
+    //Active(active);
     sink->notify(true, true);
   } catch (...) {
     active = !val;

--- a/drivers/Condition.cpp
+++ b/drivers/Condition.cpp
@@ -85,7 +85,6 @@ void Condition::setID(uint64_t val)
   id = val;
   try {
     if (active) sink->compile();
-    //ID(id);
   } catch (...) {
     id = old;
     throw;
@@ -101,7 +100,6 @@ void Condition::setMask(uint64_t val)
   mask = val;
   try {
     if (active) sink->compile();
-    //Mask(mask);
   } catch (...) {
     mask = old;
     throw;
@@ -117,7 +115,6 @@ void Condition::setOffset(int64_t val)
   offset = val;
   try {
     if (active) sink->compile();
-    //Offset(offset);
   } catch (...) {
     offset = old;
     throw;
@@ -132,7 +129,6 @@ void Condition::setAcceptLate(bool val)
   acceptLate = val;
   try {
     if (active) sink->compile();
-    //AcceptLate(val);
   } catch (...) {
     acceptLate = !val;
     throw;
@@ -148,7 +144,6 @@ void Condition::setAcceptEarly(bool val)
   acceptEarly = val;
   try {
     if (active) sink->compile();
-    //AcceptEarly(val);
   } catch (...) {
     acceptEarly = !val;
     throw;
@@ -163,7 +158,6 @@ void Condition::setAcceptConflict(bool val)
   acceptConflict = val;
   try {
     if (active) sink->compile();
-    //AcceptConflict(val);
   } catch (...) {
     acceptConflict = !val;
     throw;
@@ -178,7 +172,6 @@ void Condition::setAcceptDelayed(bool val)
   acceptDelayed = val;
   try {
     if (active) sink->compile();
-    //AcceptDelayed(val);
   } catch (...) {
     acceptDelayed = !val;
     throw;
@@ -193,8 +186,6 @@ void Condition::setActive(bool val)
   active = val;
   try {
     sink->compile();
-    //Active(active);
-    sink->notify(true, true);
   } catch (...) {
     active = !val;
     throw;

--- a/drivers/EmbeddedCPUCondition.cpp
+++ b/drivers/EmbeddedCPUCondition.cpp
@@ -44,7 +44,6 @@ void EmbeddedCPUCondition::setTag(uint32_t val)
   tag = val;
   try {
     if (active) sink->compile();
-    //Tag(tag);
   } catch (...) {
     tag = old;
     throw;

--- a/drivers/EmbeddedCPUCondition.cpp
+++ b/drivers/EmbeddedCPUCondition.cpp
@@ -44,7 +44,7 @@ void EmbeddedCPUCondition::setTag(uint32_t val)
   tag = val;
   try {
     if (active) sink->compile();
-    Tag(tag);
+    //Tag(tag);
   } catch (...) {
     tag = old;
     throw;

--- a/drivers/FunctionGenerator.cpp
+++ b/drivers/FunctionGenerator.cpp
@@ -58,7 +58,6 @@ void FunctionGenerator::on_fg_running(bool b)
 {
   if (!getOwner().empty())
   {
-    //Running(b);
     SigRunning(b);
   }
 }
@@ -67,7 +66,6 @@ void FunctionGenerator::on_fg_armed(bool b)
 {
   if (!getOwner().empty())
   {  
-    //Armed(b);
  	  SigArmed(b);
   }
 }
@@ -76,7 +74,6 @@ void FunctionGenerator::on_fg_enabled(bool b)
 {
   if (!getOwner().empty())
   {
-    //Enabled(b);
   	SigEnabled(b);
   }
 }
@@ -213,7 +210,6 @@ void FunctionGenerator::setStartTag(uint32_t val)
 {
   ownerOnly();
   fgImpl->setStartTag(val);
-  //StartTag(val);  
 }
 
 

--- a/drivers/FunctionGenerator.cpp
+++ b/drivers/FunctionGenerator.cpp
@@ -58,7 +58,7 @@ void FunctionGenerator::on_fg_running(bool b)
 {
   if (!getOwner().empty())
   {
-    Running(b);
+    //Running(b);
     SigRunning(b);
   }
 }
@@ -67,7 +67,7 @@ void FunctionGenerator::on_fg_armed(bool b)
 {
   if (!getOwner().empty())
   {  
-    Armed(b);
+    //Armed(b);
  	  SigArmed(b);
   }
 }
@@ -76,7 +76,7 @@ void FunctionGenerator::on_fg_enabled(bool b)
 {
   if (!getOwner().empty())
   {
-    Enabled(b);
+    //Enabled(b);
   	SigEnabled(b);
   }
 }
@@ -213,7 +213,7 @@ void FunctionGenerator::setStartTag(uint32_t val)
 {
   ownerOnly();
   fgImpl->setStartTag(val);
-  StartTag(val);  
+  //StartTag(val);  
 }
 
 

--- a/drivers/FunctionGeneratorFirmware.cpp
+++ b/drivers/FunctionGeneratorFirmware.cpp
@@ -97,7 +97,6 @@ FunctionGeneratorFirmware::~FunctionGeneratorFirmware()
 
 std::shared_ptr<FunctionGeneratorFirmware> FunctionGeneratorFirmware::create(const ConstructorType& args)
 {
-  // std::cerr << "WrMilGateway::create()" << std::endl;
   return RegisteredObject<FunctionGeneratorFirmware>::create(args.objectPath, args);
 }
 
@@ -128,17 +127,22 @@ bool FunctionGeneratorFirmware::nothing_runs()
 }
 
 
-// pass sigc signals from impl class to dbus
-// to reduce traffic only generate signals if we have an owner
 std::map<std::string, std::string> FunctionGeneratorFirmware::Scan()
 {
+  return ScanMasterFg();
+}
+
+// pass sigc signals from impl class to dbus
+// to reduce traffic only generate signals if we have an owner
+std::map<std::string, std::string> FunctionGeneratorFirmware::ScanMasterFg()
+{
+  ownerOnly();
   if (!nothing_runs()) {
     throw saftbus::Error(saftbus::Error::ACCESS_DENIED, "FunctionGeneratorFirmware::Scan is not allowed if any channel is active");
   }
 
   fgs_owned.clear();
   master_fgs_owned.clear();
-
 
   std::map<std::string, std::string> result;
   if (have_fg_firmware) {
@@ -183,6 +187,93 @@ std::map<std::string, std::string> FunctionGeneratorFirmware::Scan()
     cycle.close();
 
     std::vector<std::shared_ptr<FunctionGeneratorImpl> > functionGeneratorImplementations;           
+    fgs_owned.clear();
+    master_fgs_owned.clear();
+    // Create the objects to control the channels
+    for (unsigned j = 0; j < FG_MACROS_SIZE; ++j) {
+      if (!macros[j]) {
+        continue; // no hardware
+      }
+      std::ostringstream spath;
+      spath.imbue(std::locale("C"));
+      spath << objectPath << "/fg_" << j;
+      std::string path = spath.str();
+      FunctionGeneratorImpl::ConstructorType args = { path, tr, allocation, fgb, swi, sdb_msi_base, mailbox, (unsigned)num_channels, (unsigned)buffer_size, j, (uint32_t)macros[j] };
+      functionGeneratorImplementations.push_back(std::make_shared<FunctionGeneratorImpl>(args));
+    }
+
+    std::ostringstream mfg_spath;
+    mfg_spath.imbue(std::locale("C"));
+    mfg_spath << objectPath << "/masterfg";
+    std::string mfg_path = mfg_spath.str();
+
+    MasterFunctionGenerator::ConstructorType mfg_args = { mfg_path, tr, functionGeneratorImplementations};
+    std::shared_ptr<MasterFunctionGenerator> mfg = MasterFunctionGenerator::create(mfg_args);
+
+    master_fgs_owned["masterfg"] = mfg;
+    result.insert(std::make_pair("masterfg", mfg_path));
+
+  }
+
+  return result;
+}
+
+
+std::map<std::string, std::string> FunctionGeneratorFirmware::ScanFgChannels()
+{
+  ownerOnly();
+  if (!nothing_runs()) {
+    throw saftbus::Error(saftbus::Error::ACCESS_DENIED, "FunctionGeneratorFirmware::Scan is not allowed if any channel is active");
+  }
+
+  fgs_owned.clear();
+  master_fgs_owned.clear();
+
+  std::map<std::string, std::string> result;
+  if (have_fg_firmware) {
+
+    etherbone::Cycle cycle;
+
+    // get mailbox slot number for swi host=>lm32
+    eb_data_t mb_slot;
+    cycle.open(device);
+    cycle.read(fgb + SHM_BASE + FG_MB_SLOT, EB_DATA32, &mb_slot);
+    cycle.close(); 
+
+    if (mb_slot < 0 && mb_slot > 127)
+      throw saftbus::Error(saftbus::Error::INVALID_ARGS, "mailbox slot number not in range 0 to 127");
+
+    // swi address of fg is to be found in mailbox slot mb_slot
+    eb_address_t swi = mailbox.sdb_component.addr_first + mb_slot * 4 * 2;
+    clog << kLogDebug << "mailbox address for swi is 0x" << std::hex << swi << std::endl;
+    eb_data_t num_channels, buffer_size, macros[FG_MACROS_SIZE];
+    
+    tr->getDevice().write(swi, EB_DATA32, SWI_SCAN);
+    sleep(1); // this is to make sure that scanning is done when we proceed.
+              //   -> should be replaced by an MSI from the LM32 in the future.
+
+    // Probe the configuration and hardware macros
+    cycle.open(device);
+    cycle.read(fgb + SHM_BASE + FG_NUM_CHANNELS, EB_DATA32, &num_channels);
+    cycle.read(fgb + SHM_BASE + FG_BUFFER_SIZE,  EB_DATA32, &buffer_size);
+    for (unsigned j = 0; j < FG_MACROS_SIZE; ++j)
+      cycle.read(fgb + SHM_BASE + FG_MACROS + j*4, EB_DATA32, &macros[j]);
+    cycle.close();
+    
+    // Create an allocation buffer
+    std::shared_ptr<std::vector<int>> allocation(
+      new std::vector<int>);
+    allocation->resize(num_channels, -1);
+    
+    // Disable all channels
+    cycle.open(device);
+    for (unsigned j = 0; j < num_channels; ++j)
+      cycle.write(swi, EB_DATA32, SWI_DISABLE | j);
+    cycle.close();
+
+    std::vector<std::shared_ptr<FunctionGeneratorImpl> > functionGeneratorImplementations;           
+    fgs_owned.clear();
+    master_fgs_owned.clear();
     // Create the objects to control the channels
     for (unsigned j = 0; j < FG_MACROS_SIZE; ++j) {
             if (!macros[j]) {
@@ -195,29 +286,15 @@ std::map<std::string, std::string> FunctionGeneratorFirmware::Scan()
       std::string path = spath.str();
       
       FunctionGeneratorImpl::ConstructorType args = { path, tr, allocation, fgb, swi, sdb_msi_base, mailbox, (unsigned)num_channels, (unsigned)buffer_size, j, (uint32_t)macros[j] };
-      std::shared_ptr<FunctionGeneratorImpl> fgImpl(new FunctionGeneratorImpl(args));
-      functionGeneratorImplementations.push_back(fgImpl);
-      
-      FunctionGenerator::ConstructorType fgargs = { path, tr, fgImpl };
+      FunctionGenerator::ConstructorType fgargs = { path, tr, std::make_shared<FunctionGeneratorImpl>(args) };
       std::shared_ptr<FunctionGenerator> fg = FunctionGenerator::create(fgargs);       
       std::ostringstream name;
       name.imbue(std::locale("C"));
-      name << "fg-" << (int)fgImpl->getSCUbusSlot() << "-" << (int)fgImpl->getDeviceNumber();
+      name << "fg-" << (int)fgargs.functionGeneratorImpl->getSCUbusSlot() 
+           << "-"   << (int)fgargs.functionGeneratorImpl->getDeviceNumber();
       fgs_owned[name.str()] = fg;
       result.insert(std::make_pair(name.str(), path));
-
     }
-
-    std::ostringstream mfg_spath;
-    mfg_spath.imbue(std::locale("C"));
-    mfg_spath << objectPath << "/masterfg";
-    std::string mfg_path = mfg_spath.str();
-
-    MasterFunctionGenerator::ConstructorType mfg_args = { mfg_path, tr, functionGeneratorImplementations};
-    std::shared_ptr<MasterFunctionGenerator> mfg = MasterFunctionGenerator::create(mfg_args);
-
-    master_fgs_owned["masterfg"] = mfg;
-
   }
 
   return result;

--- a/drivers/FunctionGeneratorFirmware.h
+++ b/drivers/FunctionGeneratorFirmware.h
@@ -63,6 +63,8 @@ class FunctionGeneratorFirmware : public Owned, public iFunctionGeneratorFirmwar
     FunctionGeneratorFirmware(const ConstructorType& args);
     ~FunctionGeneratorFirmware();
 
+    bool nothing_runs();
+
     std::string                objectPath;
     TimingReceiver             *tr;
     Device&                    device;

--- a/drivers/FunctionGeneratorFirmware.h
+++ b/drivers/FunctionGeneratorFirmware.h
@@ -32,6 +32,8 @@
 #include <deque>
 
 #include "interfaces/FunctionGeneratorFirmware.h"
+#include "FunctionGenerator.h"
+#include "MasterFunctionGenerator.h"
 #include "Owned.h"
 
 namespace saftlib {
@@ -58,6 +60,10 @@ class FunctionGeneratorFirmware : public Owned, public iFunctionGeneratorFirmwar
     // iFunctionGenerator overrides
     uint32_t getVersion() const;
     std::map<std::string, std::string> Scan();
+    std::map<std::string, std::string> ScanMasterFg();
+    std::map<std::string, std::string> ScanFgChannels();
+
+    void removeMasterFunctionGenerator();
     
   protected:
     FunctionGeneratorFirmware(const ConstructorType& args);

--- a/drivers/FunctionGeneratorImpl.cpp
+++ b/drivers/FunctionGeneratorImpl.cpp
@@ -70,10 +70,14 @@ FunctionGeneratorImpl::FunctionGeneratorImpl(const ConstructorType& args)
     slot++;
   }
 
-  if (slot < 128)
+  if (slot < 128) {
     mbx_slot = --slot;
-  else
+  }
+  else {
     clog << kLogErr << "FunctionGenerator: no free slot in mailbox left"  << std::endl;
+  }
+
+
 
   //save the irq address in the odd mailbox slot
   //keep postal address to free later

--- a/drivers/Input.cpp
+++ b/drivers/Input.cpp
@@ -38,9 +38,9 @@ Input::Input(const ConstructorType& args)
    impl(args.impl), partnerPath(args.partnerPath),
    tlu(args.tlu), channel(args.channel), enable(false), event(0), stable(80)
 {
-  impl->InputTermination.connect(InputTermination.make_slot());
-  impl->SpecialPurposeIn.connect(SpecialPurposeIn.make_slot());
-  impl->GateIn.connect(GateIn.make_slot());
+  //impl->InputTermination.connect(InputTermination.make_slot());
+  //impl->SpecialPurposeIn.connect(SpecialPurposeIn.make_slot());
+  //impl->GateIn.connect(GateIn.make_slot());
   // initialize TLU to disabled state
   configInput();
 }
@@ -155,7 +155,7 @@ void Input::setEventEnable(bool val)
   enable = val;
 
   configInput();
-  EventEnable(val);
+  //EventEnable(val);
 }
 
 void Input::setEventPrefix(uint64_t val)
@@ -169,7 +169,7 @@ void Input::setEventPrefix(uint64_t val)
   event = val;
 
   configInput();
-  EventPrefix(val);
+  //EventPrefix(val);
 }
 
 void Input::setStableTime(uint32_t val)
@@ -185,7 +185,7 @@ void Input::setStableTime(uint32_t val)
   stable = val;
 
   configInput();
-  StableTime(val);
+  //StableTime(val);
 }
 
 void Input::configInput()

--- a/drivers/Input.cpp
+++ b/drivers/Input.cpp
@@ -38,9 +38,6 @@ Input::Input(const ConstructorType& args)
    impl(args.impl), partnerPath(args.partnerPath),
    tlu(args.tlu), channel(args.channel), enable(false), event(0), stable(80)
 {
-  //impl->InputTermination.connect(InputTermination.make_slot());
-  //impl->SpecialPurposeIn.connect(SpecialPurposeIn.make_slot());
-  //impl->GateIn.connect(GateIn.make_slot());
   // initialize TLU to disabled state
   configInput();
 }
@@ -155,7 +152,6 @@ void Input::setEventEnable(bool val)
   enable = val;
 
   configInput();
-  //EventEnable(val);
 }
 
 void Input::setEventPrefix(uint64_t val)
@@ -169,7 +165,6 @@ void Input::setEventPrefix(uint64_t val)
   event = val;
 
   configInput();
-  //EventPrefix(val);
 }
 
 void Input::setStableTime(uint32_t val)
@@ -185,7 +180,6 @@ void Input::setStableTime(uint32_t val)
   stable = val;
 
   configInput();
-  //StableTime(val);
 }
 
 void Input::configInput()

--- a/drivers/MILbusCondition.cpp
+++ b/drivers/MILbusCondition.cpp
@@ -47,7 +47,7 @@ void MILbusCondition::setTag(uint16_t val)
   tag = val;
   try {
     if (active) sink->compile();
-    Tag(tag);
+    //Tag(tag);
   } catch (...) {
     tag = old;
     throw;

--- a/drivers/MILbusCondition.cpp
+++ b/drivers/MILbusCondition.cpp
@@ -47,7 +47,6 @@ void MILbusCondition::setTag(uint16_t val)
   tag = val;
   try {
     if (active) sink->compile();
-    //Tag(tag);
   } catch (...) {
     tag = old;
     throw;

--- a/drivers/MasterFunctionGenerator.cpp
+++ b/drivers/MasterFunctionGenerator.cpp
@@ -424,7 +424,7 @@ void MasterFunctionGenerator::setStartTag(uint32_t val)
 			fg->startTag=startTag;
 		}
 
-    StartTag(startTag);
+    //StartTag(startTag);
   }
 }
 

--- a/drivers/MasterFunctionGenerator.cpp
+++ b/drivers/MasterFunctionGenerator.cpp
@@ -432,8 +432,6 @@ void MasterFunctionGenerator::setStartTag(uint32_t val)
 		{
 			fg->startTag=startTag;
 		}
-
-    //StartTag(startTag);
   }
 }
 

--- a/drivers/MasterFunctionGenerator.cpp
+++ b/drivers/MasterFunctionGenerator.cpp
@@ -56,7 +56,16 @@ MasterFunctionGenerator::MasterFunctionGenerator(const ConstructorType& args)
 
 MasterFunctionGenerator::~MasterFunctionGenerator()
 {
-      
+  for (auto fg : allFunctionGenerators) {
+    fg->signal_running.clear();
+    fg->signal_armed.clear();
+    fg->signal_enabled.clear();
+    fg->signal_started.clear();
+    fg->signal_stopped.clear();
+    fg->signal_refill.clear();
+  }
+  allFunctionGenerators.clear();
+  activeFunctionGenerators.clear();
 }
 
 // aggregate sigc signals from impl and forward via dbus where necessary

--- a/drivers/MasterFunctionGenerator.h
+++ b/drivers/MasterFunctionGenerator.h
@@ -94,7 +94,6 @@ class MasterFunctionGenerator : public Owned, public iMasterFunctionGenerator
     void on_fg_stopped(std::shared_ptr<FunctionGeneratorImpl>& fg, uint64_t time, bool abort, bool hardwareUnderflow, bool microcontrollerUnderflow);
     void on_fg_refill(std::shared_ptr<FunctionGeneratorImpl>& fg);
 
-
     bool all_armed();
     bool all_stopped();
     bool WaitTimeout();

--- a/drivers/Output.cpp
+++ b/drivers/Output.cpp
@@ -37,11 +37,6 @@ Output::Output(const ConstructorType& args) :
   ActionSink(args.objectPath, args.dev, args.name, args.channel, args.num, args.destroy),
   impl(args.impl), partnerPath(args.partnerPath)
 {
-  // impl->OutputEnable.connect(OutputEnable.make_slot());
-  // impl->SpecialPurposeOut.connect(SpecialPurposeOut.make_slot());
-  // impl->GateOut.connect(GateOut.make_slot());
-  // impl->BuTiSMultiplexer.connect(BuTiSMultiplexer.make_slot());
-  // impl->PPSMultiplexer.connect(PPSMultiplexer.make_slot());
 }
 
 const char *Output::getInterfaceName() const

--- a/drivers/Output.cpp
+++ b/drivers/Output.cpp
@@ -37,11 +37,11 @@ Output::Output(const ConstructorType& args) :
   ActionSink(args.objectPath, args.dev, args.name, args.channel, args.num, args.destroy),
   impl(args.impl), partnerPath(args.partnerPath)
 {
-  impl->OutputEnable.connect(OutputEnable.make_slot());
-  impl->SpecialPurposeOut.connect(SpecialPurposeOut.make_slot());
-  impl->GateOut.connect(GateOut.make_slot());
-  impl->BuTiSMultiplexer.connect(BuTiSMultiplexer.make_slot());
-  impl->PPSMultiplexer.connect(PPSMultiplexer.make_slot());
+  // impl->OutputEnable.connect(OutputEnable.make_slot());
+  // impl->SpecialPurposeOut.connect(SpecialPurposeOut.make_slot());
+  // impl->GateOut.connect(GateOut.make_slot());
+  // impl->BuTiSMultiplexer.connect(BuTiSMultiplexer.make_slot());
+  // impl->PPSMultiplexer.connect(PPSMultiplexer.make_slot());
 }
 
 const char *Output::getInterfaceName() const

--- a/drivers/OutputCondition.cpp
+++ b/drivers/OutputCondition.cpp
@@ -49,7 +49,7 @@ void OutputCondition::setOn(bool v)
   tag = val;
   try {
     if (active) sink->compile();
-    On(tag);
+    //On(tag);
   } catch (...) {
     tag = old;
     throw;

--- a/drivers/OutputCondition.cpp
+++ b/drivers/OutputCondition.cpp
@@ -49,7 +49,6 @@ void OutputCondition::setOn(bool v)
   tag = val;
   try {
     if (active) sink->compile();
-    //On(tag);
   } catch (...) {
     tag = old;
     throw;

--- a/drivers/Owned.cpp
+++ b/drivers/Owned.cpp
@@ -56,7 +56,7 @@ void Owned::Disown()
     ownerOnly();
     unsubscribe();
     owner.clear();
-    Owner(owner);
+    //Owner(owner);
   }
 }
 
@@ -78,7 +78,7 @@ void Owned::initOwner(const std::shared_ptr<saftbus::Connection>& connection_, c
         "/org/freedesktop/DBus",
         owner);
     unsubscribe = sigc::bind(sigc::ptr_fun(&do_unsubscribe), connection, subscription_id);
-    Owner(owner);
+    //Owner(owner);
   } else {
     throw saftbus::Error(saftbus::Error::INVALID_ARGS, "Already have an Owner");
   }
@@ -122,7 +122,7 @@ void Owned::owner_quit_handler(
   try {
     self->unsubscribe();
     self->owner.clear();
-    self->Owner(self->owner);
+    //self->Owner(self->owner);
     self->ownerQuit(); // inform base classes, in case they have clean-up code
     
     if (self->getDestructible()) self->destroy();

--- a/drivers/Owned.cpp
+++ b/drivers/Owned.cpp
@@ -56,7 +56,6 @@ void Owned::Disown()
     ownerOnly();
     unsubscribe();
     owner.clear();
-    //Owner(owner);
   }
 }
 
@@ -78,7 +77,6 @@ void Owned::initOwner(const std::shared_ptr<saftbus::Connection>& connection_, c
         "/org/freedesktop/DBus",
         owner);
     unsubscribe = sigc::bind(sigc::ptr_fun(&do_unsubscribe), connection, subscription_id);
-    //Owner(owner);
   } else {
     throw saftbus::Error(saftbus::Error::INVALID_ARGS, "Already have an Owner");
   }
@@ -122,7 +120,6 @@ void Owned::owner_quit_handler(
   try {
     self->unsubscribe();
     self->owner.clear();
-    //self->Owner(self->owner);
     self->ownerQuit(); // inform base classes, in case they have clean-up code
     
     if (self->getDestructible()) self->destroy();

--- a/drivers/SCUbusCondition.cpp
+++ b/drivers/SCUbusCondition.cpp
@@ -47,7 +47,6 @@ void SCUbusCondition::setTag(uint32_t val)
   tag = val;
   try {
     if (active) sink->compile();
-    //Tag(tag);
   } catch (...) {
     tag = old;
     throw;

--- a/drivers/SCUbusCondition.cpp
+++ b/drivers/SCUbusCondition.cpp
@@ -47,7 +47,7 @@ void SCUbusCondition::setTag(uint32_t val)
   tag = val;
   try {
     if (active) sink->compile();
-    Tag(tag);
+    //Tag(tag);
   } catch (...) {
     tag = old;
     throw;

--- a/drivers/TimingReceiver.cpp
+++ b/drivers/TimingReceiver.cpp
@@ -355,7 +355,7 @@ bool TimingReceiver::getLocked() const
   if (newLocked != locked) {
     locked = newLocked;
     SigLocked(locked);
-    Locked(locked);
+    //Locked(locked);
   }
   
   return newLocked;
@@ -383,8 +383,8 @@ int32_t TimingReceiver::CurrentTemperature()
 void TimingReceiver::do_remove(SinkKey key)
 {
   actionSinks[key].reset();
-  SoftwareActionSinks(getSoftwareActionSinks());
-  Interfaces(getInterfaces());
+  //SoftwareActionSinks(getSoftwareActionSinks());
+  //Interfaces(getInterfaces());
   compile();
 }
 
@@ -437,8 +437,8 @@ std::string TimingReceiver::NewSoftwareActionSink(const std::string& name_)
   
   // Own it and inform changes to properties
   alloc->second = softwareActionSink;
-  SoftwareActionSinks(getSoftwareActionSinks());
-  Interfaces(getInterfaces());
+  //SoftwareActionSinks(getSoftwareActionSinks());
+  //Interfaces(getInterfaces());
   
   return path;
 }
@@ -627,10 +627,10 @@ uint16_t TimingReceiver::updateMostFull(unsigned channel)
     ActionSinks::iterator first = actionSinks.lower_bound(low);
     ActionSinks::iterator last  = actionSinks.lower_bound(high);
     
-    for (; first != last; ++first) {
-      if (!first->second) continue; // skip unused SoftwareActionSinks
-      first->second->MostFull(mostFull);
-    }
+    // for (; first != last; ++first) {
+    //   if (!first->second) continue; // skip unused SoftwareActionSinks
+    //   first->second->MostFull(mostFull);
+    // }
   }
   
   return used;

--- a/drivers/TimingReceiver.cpp
+++ b/drivers/TimingReceiver.cpp
@@ -355,7 +355,6 @@ bool TimingReceiver::getLocked() const
   if (newLocked != locked) {
     locked = newLocked;
     SigLocked(locked);
-    //Locked(locked);
   }
   
   return newLocked;
@@ -383,8 +382,6 @@ int32_t TimingReceiver::CurrentTemperature()
 void TimingReceiver::do_remove(SinkKey key)
 {
   actionSinks[key].reset();
-  //SoftwareActionSinks(getSoftwareActionSinks());
-  //Interfaces(getInterfaces());
   compile();
 }
 
@@ -437,26 +434,12 @@ std::string TimingReceiver::NewSoftwareActionSink(const std::string& name_)
   
   // Own it and inform changes to properties
   alloc->second = softwareActionSink;
-  //SoftwareActionSinks(getSoftwareActionSinks());
-  //Interfaces(getInterfaces());
   
   return path;
 }
 
 void TimingReceiver::InjectEvent(uint64_t event, uint64_t param, uint64_t time)
 {
-  // etherbone::Cycle cycle;
-  
-  // cycle.open(device);
-  // cycle.write(stream, EB_DATA32, event >> 32);
-  // cycle.write(stream, EB_DATA32, event & 0xFFFFFFFFUL);
-  // cycle.write(stream, EB_DATA32, param >> 32);
-  // cycle.write(stream, EB_DATA32, param & 0xFFFFFFFFUL);
-  // cycle.write(stream, EB_DATA32, 0); // reserved
-  // cycle.write(stream, EB_DATA32, 0); // TEF
-  // cycle.write(stream, EB_DATA32, time >> 32);
-  // cycle.write(stream, EB_DATA32, time & 0xFFFFFFFFUL);
-  // cycle.close();
   InjectEvent(event,param,makeTimeTAI(time));
 }
 
@@ -511,8 +494,6 @@ std::map< std::string, std::string > TimingReceiver::getSoftwareActionSinks() co
   for (iterator i = actionSinks.begin(); i != actionSinks.end(); ++i) {
     std::shared_ptr<SoftwareActionSink> softwareActionSink =
       std::dynamic_pointer_cast<SoftwareActionSink>(i->second);
-    // std::shared_ptr<SoftwareActionSink> softwareActionSink =
-    //   std::shared_ptr<SoftwareActionSink>::cast_dynamic(i->second);
     if (!softwareActionSink) continue;
     out[softwareActionSink->getObjectName()] = softwareActionSink->getObjectPath();
   }
@@ -526,8 +507,6 @@ std::map< std::string, std::string > TimingReceiver::getOutputs() const
   for (iterator i = actionSinks.begin(); i != actionSinks.end(); ++i) {
     std::shared_ptr<Output> output =
       std::dynamic_pointer_cast<Output>(i->second);
-    // std::shared_ptr<Output> output =
-    //   std::shared_ptr<Output>::cast_dynamic(i->second);
     if (!output) continue;
     out[output->getObjectName()] = output->getObjectPath();
   }
@@ -541,8 +520,6 @@ std::map< std::string, std::string > TimingReceiver::getInputs() const
   for (iterator i = eventSources.begin(); i != eventSources.end(); ++i) {
     std::shared_ptr<Input> input =
       std::dynamic_pointer_cast<Input>(i->second);
-    // std::shared_ptr<Input> input =
-    //   std::shared_ptr<Input>::cast_dynamic(i->second);
     if (!input) continue;
     out[input->getObjectName()] = input->getObjectPath();
   }
@@ -621,16 +598,12 @@ uint16_t TimingReceiver::updateMostFull(unsigned channel)
   if (most_full[channel] != mostFull) {
     most_full[channel] = mostFull;
     
-    // Broadcast new value to all subchannels
-    SinkKey low(channel, 0);
-    SinkKey high(channel+1, 0);
-    ActionSinks::iterator first = actionSinks.lower_bound(low);
-    ActionSinks::iterator last  = actionSinks.lower_bound(high);
-    
-    // for (; first != last; ++first) {
-    //   if (!first->second) continue; // skip unused SoftwareActionSinks
-    //   first->second->MostFull(mostFull);
-    // }
+    // // Broadcast new value to all subchannels
+    // maybe introduce a signal for this (is anyone using this?)
+    // SinkKey low(channel, 0);
+    // SinkKey high(channel+1, 0);
+    // ActionSinks::iterator first = actionSinks.lower_bound(low);
+    // ActionSinks::iterator last  = actionSinks.lower_bound(high);
   }
   
   return used;

--- a/drivers/WrMilGateway.cpp
+++ b/drivers/WrMilGateway.cpp
@@ -351,6 +351,10 @@ void WrMilGateway::KillGateway()
   ClearStatistics();
   writeRegisterContent(WR_MIL_GW_REG_COMMAND, WR_MIL_GW_CMD_KILL);
 }
+void WrMilGateway::UpdateOLED()
+{
+  writeRegisterContent(WR_MIL_GW_REG_COMMAND, WR_MIL_GW_CMD_UPDATE_OLED);
+}
 
 
 uint32_t WrMilGateway::getWrMilMagic() const
@@ -485,7 +489,10 @@ void WrMilGateway::setUtcOffset(uint64_t val)
   val >>= 32;
   writeRegisterContent(WR_MIL_GW_REG_UTC_OFFSET_HI, val & 0x00000000ffffffff);
 }
-
+void WrMilGateway::setOpReady(bool val)
+{
+  writeRegisterContent(WR_MIL_GW_REG_SET_OP_READY, val);
+}
 
 
 void WrMilGateway::Reset() 

--- a/drivers/WrMilGateway.h
+++ b/drivers/WrMilGateway.h
@@ -58,6 +58,7 @@ class WrMilGateway : public Owned, public iWrMilGateway
     void ClearStatistics();
     void ResetGateway();
     void KillGateway();
+    void UpdateOLED();
 
     std::vector< uint32_t > getRegisterContent()  const;
     std::vector< uint32_t > getMilHistogram()     const;
@@ -80,6 +81,7 @@ class WrMilGateway : public Owned, public iWrMilGateway
     void setUtcUtcDelay(uint32_t val);
     void setTriggerUtcDelay(uint32_t val);
     void setUtcOffset(uint64_t val);
+    void setOpReady(bool val);
     
   protected:
     WrMilGateway(const ConstructorType& args);

--- a/drivers/wr_mil_gw_regs.h
+++ b/drivers/wr_mil_gw_regs.h
@@ -13,6 +13,7 @@
 #define WR_MIL_GW_CMD_CONFIG_SIS     0x3   // command to configure the gateway for SIS operation
 #define WR_MIL_GW_CMD_CONFIG_ESR     0x4   // command to configure the gateway for ESR operation
 #define WR_MIL_GW_CMD_TEST           0x5   // command that does nothing. it is useful to initiate to see if the firmware cleans the command register (see if the firmware runs at all)
+#define WR_MIL_GW_CMD_UPDATE_OLED    0x6   // redraw content on OLED
 
 
 // Configuration register mapping in shared memory region
@@ -32,6 +33,7 @@
 #define WR_MIL_GW_REG_LATE_HISTOGRAM 0x34  // dummy register to indicate position after the last valid register
 #define WR_MIL_GW_REG_MIL_HISTOGRAM  0x74  // dummy register to indicate position after the last valid register
 #define WR_MIL_GW_REG_MSI_SLOT       0x474 // MSI slot is stored here
+#define WR_MIL_GW_REG_SET_OP_READY   0x478 // Host writes 1 if OP-READY, 0 otherwise
 
 // states of the software
 #define WR_MIL_GW_STATE_INIT         0

--- a/interfaces/ActionSink.xml
+++ b/interfaces/ActionSink.xml
@@ -222,7 +222,7 @@
     -->
   <property name="LateCount" type="t" access="readwrite"/>
   
-  <!-- Late:      An example of a late action since last LateCount change.
+  <!-- Late:      Deprecated! Use SigLate instead.
        @count:    The new value of LateCount when this signal was raised.
        @event:    The event identifier of the late action.
        @param:    The parameter field, whose meaning depends on the event ID.
@@ -241,7 +241,18 @@
     <arg name="deadline" type="t"/>
     <arg name="executed" type="t"/>
   </signal>
+  <!-- Late:      An example of a late action since last LateCount change.
+       @count:    The new value of LateCount when this signal was raised.
+       @event:    The event identifier of the late action.
+       @param:    The parameter field, whose meaning depends on the event ID.
+       @deadline: The desired execution timestamp (event time + offset).
+       @executed: The actual execution timestamp.
 
+       Keep in mind that an action is only counted as late if it is
+       scheduled for the past.  An action which leaves the timing receiver
+       after its deadline, due to a slow consumer, is a delayed (not late)
+       action.
+    -->
   <signal name="SigLate">
     <arg name="count"    type="u"/>
     <arg name="event"    type="t"/>
@@ -264,7 +275,7 @@
     -->
   <property name="EarlyCount" type="t" access="readwrite"/>
   
-  <!-- Early:     An example of an early action since last EarlyCount change.
+  <!-- Early:     Deprecated! Use SigEarly instead.
        @count:    The new value of LateCount when this signal was raised.
        @event:    The event identifier of the early action.
        @param:    The parameter field, whose meaning depends on the event ID.
@@ -278,7 +289,14 @@
     <arg name="deadline" type="t"/>
     <arg name="executed" type="t"/>
   </signal>
-  <signal name="SigEarly">
+  <!-- Early:     An example of an early action since last EarlyCount change.
+       @count:    The new value of LateCount when this signal was raised.
+       @event:    The event identifier of the early action.
+       @param:    The parameter field, whose meaning depends on the event ID.
+       @deadline: The desired execution timestamp (event time + offset).
+       @executed: The actual execution timestamp.
+    -->
+    <signal name="SigEarly">
     <arg name="count"    type="u"/>
     <arg name="event"    type="t"/>
     <arg name="param"    type="t"/>
@@ -298,7 +316,7 @@
     -->
   <property name="ConflictCount" type="t" access="readwrite"/>
   
-  <!-- Conflict:  An example of a conflict since last ConflictCount change.
+  <!-- Conflict:  Deprecated! use SigConflict instead.
        @count:    The new value of ConflictCount when this signal was raised.
        @event:    The event identifier of a conflicting action.
        @param:    The parameter field, whose meaning depends on the event ID.
@@ -312,6 +330,13 @@
     <arg name="deadline" type="t"/>
     <arg name="executed" type="t"/>
   </signal>
+  <!-- Conflict:  An example of a conflict since last ConflictCount change.
+       @count:    The new value of ConflictCount when this signal was raised.
+       @event:    The event identifier of a conflicting action.
+       @param:    The parameter field, whose meaning depends on the event ID.
+       @deadline: The scheduled action execution timestamp (event time + offset).
+       @executed: The timestamp when the action was actually executed.
+    -->  
   <signal name="SigConflict">
     <arg name="count"    type="t"/>
     <arg name="event"    type="t"/>
@@ -334,7 +359,7 @@
     -->
   <property name="DelayedCount" type="t" access="readwrite"/>
   
-  <!-- Delayed:   An example of a delayed action the last DelayedCount change.
+  <!-- Delayed:   Deprecated! Use SigDelayed instead.
        @count:    The value of DelayedCount when this signal was raised.
        @event:    The event identifier of the delayed action.
        @param:    The parameter field, whose meaning depends on the event ID.
@@ -348,6 +373,13 @@
     <arg name="deadline" type="t"/>
     <arg name="executed" type="t"/>
   </signal>
+  <!-- Delayed:   An example of a delayed action the last DelayedCount change.
+       @count:    The value of DelayedCount when this signal was raised.
+       @event:    The event identifier of the delayed action.
+       @param:    The parameter field, whose meaning depends on the event ID.
+       @deadline: The desired execution timestamp (event time + offset).
+       @executed: The timestamp when the action was actually executed.
+    -->
   <signal name="SigDelayed">
     <arg name="count"    type="t"/>
     <arg name="event"    type="t"/>

--- a/interfaces/FunctionGenerator.xml
+++ b/interfaces/FunctionGenerator.xml
@@ -90,7 +90,7 @@
       <arg name="running" type="b"/>
     </signal>
 
-    <!-- Started: Function generation has begun.
+    <!-- Started: Deprecated! use SigStarted instead.
          @time:   Time when function generation began in nanoseconds since 1970
          This signal notifies software when function generation has begun,
          possibly to update a GUI or other user-facing status information.
@@ -98,11 +98,29 @@
     <signal name="Started" deprecated="yes">
       <arg name="time" type="t"/>
     </signal>
+    <!-- SigStarted: Function generation has begun.
+         @time:   Time when function generation began in nanoseconds since 1970
+         This signal notifies software when function generation has begun,
+         possibly to update a GUI or other user-facing status information.
+      -->
     <signal name="SigStarted">
       <arg name="time" type="T"/>
     </signal>
 
-    <!-- Stopped:                   Function generation has ended.
+    <!-- Stopped:                   Deprecated! Use SigStopped instead.
+         @time:                     Time when function generation ended in nanoseconds since 1970
+         @abort:                    stopped due to a call to Abort
+         @hardwareMacroUnderflow:   A fatal error, indicating the SCUbus is congested
+         @microControllerUnderflow: A fatal error, indicating the host CPU is overloaded
+      -->
+    <signal name="Stopped" deprecated="yes">
+      <arg name="time"                     type="t"/>
+      <arg name="aborted"                  type="b"/>
+      <arg name="hardwareMacroUnderflow"   type="b"/>
+      <arg name="microControllerUnderflow" type="b"/>
+    </signal>
+
+    <!-- SigStopped:                   Function generation has ended.
          @time:                     Time when function generation ended in nanoseconds since 1970
          @abort:                    stopped due to a call to Abort
          @hardwareMacroUnderflow:   A fatal error, indicating the SCUbus is congested
@@ -126,13 +144,7 @@
          next time the function generator starts. After stopping, regardless of if the generation
          was successful or not, the parameter FIFO is cleared, Enabled is false, and this signal emitted.
       -->
-    <signal name="Stopped" deprecated="yes">
-      <arg name="time"                     type="t"/>
-      <arg name="aborted"                  type="b"/>
-      <arg name="hardwareMacroUnderflow"   type="b"/>
-      <arg name="microControllerUnderflow" type="b"/>
-    </signal>
-    <signal name="SigStopped">
+      <signal name="SigStopped">
       <arg name="time"                     type="T"/>
       <arg name="aborted"                  type="b"/>
       <arg name="hardwareMacroUnderflow"   type="b"/>

--- a/interfaces/FunctionGeneratorFirmware.xml
+++ b/interfaces/FunctionGeneratorFirmware.xml
@@ -24,5 +24,11 @@
     <method name="Scan">
       <arg direction="out" type="a{ss}" name="fgs"/>
     </method>
+    <method name="ScanMasterFg">
+      <arg direction="out" type="a{ss}" name="fgs"/>
+    </method>
+    <method name="ScanFgChannels">
+      <arg direction="out" type="a{ss}" name="fgs"/>
+    </method>
   </interface>
 </node>

--- a/interfaces/FunctionGeneratorFirmware.xml
+++ b/interfaces/FunctionGeneratorFirmware.xml
@@ -16,7 +16,9 @@
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
     </property>
     
-    <!-- Scan: Scan bus for fg channels.
+    <!-- Scan: Scan bus for fg channels. 
+               This function should only be called if no fg-channel is active.
+               If any channel is active and this function is called a saftbus::Error will be thrown!
          @result:   fgs found.
       -->
     <method name="Scan">

--- a/interfaces/Makefile.am
+++ b/interfaces/Makefile.am
@@ -83,7 +83,9 @@ doc_DATA = 			\
 	Device.pdf		\
 	SAFTd.pdf		\
 	EventSource.pdf		\
+	FunctionGeneratorFirmware.pdf	\
 	FunctionGenerator.pdf	\
+	MasterFunctionGenerator.pdf	\
 	InputEventSource.pdf	\
 	MILbusActionSink.pdf	\
 	MILbusCondition.pdf	\
@@ -97,7 +99,11 @@ doc_DATA = 			\
 	SoftwareActionSink.pdf	\
 	SoftwareCondition.pdf	\
 	TimingReceiver.pdf     \
-	WrMilGateway.pdf
+	WrMilGateway.pdf     \
+	Types.pdf
+
+Types.pdf: Types.texi
+	$(TEXI2PDF) Types.texi
 endif
 
 libsaftlib_la_LIBADD = $(SIGCPP_LIBS)
@@ -153,9 +159,11 @@ $(doc_DATA:.pdf=.doc-xml) $(nodist_libsaftlib_la_SOURCES) $(nodist_saftlib_HEADE
 	$(XSLTPROC) --path $(srcdir) --xinclude $(srcdir)/doc.xsl $(NODES)
 
 .doc-xml.pdf:
-	rm -f docfoo-*.$*.*
+	rm -f docfoo-*.$*.* 
 	$(GDBUS_CODEGEN) --generate-docbook=docfoo --interface-prefix=de.gsi.saftlib $<
-	$(XSLTPROC) --path $(srcdir) fix-docbook.xsl docfoo-*.$*.xml > docfoo-fix.$*.xml
-	$(DOCBOOK2PDF) docfoo-fix.$*.xml
+	$(XSLTPROC) --path $(srcdir) fix-docbook.xsl docfoo-de.gsi.saftlib.$*.xml > docfoo-fix.$*.xml
+	$(DOCBOOK2TEXI) --string-param output-file=docfoo-fix.$* docfoo-fix.$*.xml
+	$(TEXI2PDF) docfoo-fix.$*.texi	
 	mv docfoo-*.$*.pdf $@
-	rm -f docfoo-*.$*.*
+	rm -f docfoo-de.gsi.saftlib.$*.xml docfoo-fix.$*.* 
+

--- a/interfaces/Makefile.am
+++ b/interfaces/Makefile.am
@@ -103,7 +103,7 @@ doc_DATA = 			\
 	Types.pdf
 
 Types.pdf: Types.texi
-	$(TEXI2PDF) Types.texi
+	$(TEXI2PDF) Types.texi; rm Types.aux Types.log Types.toc
 endif
 
 libsaftlib_la_LIBADD = $(SIGCPP_LIBS)

--- a/interfaces/MasterFunctionGenerator.xml
+++ b/interfaces/MasterFunctionGenerator.xml
@@ -80,7 +80,7 @@
 
          Parameters are sent as a vector of vectors. 
          The outside vectors contain a coefficient vector for each FG and must be of the same size
-         and <= the number of active FGs.
+         and less or equal the number of active FGs.
          The coefficient vectors for each FG's parameter set must be the same size
          but different FGs may have different parameter set sizes. 
          If there is no data for an individual function generator an empty vector 
@@ -131,7 +131,21 @@
     <method name="Flush"/>
 
 
-    <!-- Stopped: Stopped signal forwarded from a single Function Generator
+    <!-- Stopped: Deprecated! Use SigStopped instead.
+         @name:                     Name of the FG that generated the signal.
+         @time:                     Time when function generation ended in nanoseconds since 1970
+         @abort:                    stopped due to a call to Abort
+         @hardwareMacroUnderflow:   A fatal error, indicating the SCUbus is congested
+         @microControllerUnderflow: A fatal error, indicating the host CPU is overloaded
+      -->
+    <signal name="Stopped" deprecated="yes">
+      <arg name="name"                     type="s"/>
+      <arg name="time"                     type="t"/>
+      <arg name="aborted"                  type="b"/>
+      <arg name="hardwareMacroUnderflow"   type="b"/>
+      <arg name="microControllerUnderflow" type="b"/>
+    </signal>
+    <!-- SigStopped: Stopped signal forwarded from a single Function Generator
          @name:                     Name of the FG that generated the signal.
          @time:                     Time when function generation ended in nanoseconds since 1970
          @abort:                    stopped due to a call to Abort
@@ -156,13 +170,6 @@
          next time the function generator starts. After stopping, regardless of if the generation
          was successful or not, the parameter FIFO is cleared, Enabled is false, and this signal emitted.
       -->
-    <signal name="Stopped" deprecated="yes">
-      <arg name="name"                     type="s"/>
-      <arg name="time"                     type="t"/>
-      <arg name="aborted"                  type="b"/>
-      <arg name="hardwareMacroUnderflow"   type="b"/>
-      <arg name="microControllerUnderflow" type="b"/>
-    </signal>
     <signal name="SigStopped">
       <arg name="name"                     type="s"/>
       <arg name="time"                     type="T"/>
@@ -193,12 +200,14 @@
       <arg name="running"                  type="b"/>
     </signal>
 
-    <!-- Started: Started signal forwarded from a single Function Generator
+    <!-- Started: Deprecated! Use SigStarted instead.
          -->
     <signal name="Started" deprecated="yes">
       <arg name="name"                     type="s"/>
       <arg name="time"                     type="t"/>
     </signal>
+    <!-- SigStarted: Started signal forwarded from a single Function Generator
+         -->
     <signal name="SigStarted">
       <arg name="name"                     type="s"/>
       <arg name="time"                     type="T"/>
@@ -210,16 +219,21 @@
       <arg name="name"                     type="s"/>
     </signal>
 
-    <!-- AllStopped:                All Function generators have stopped.
+    <!-- AllStopped:                Deprecated! Use SigAllStopped instead.
          @time:                     Time when last function generation ended in nanoseconds since 1970
 
          This signal is generated when a function generator stops and all function generators
          controlled by this master have then stopped. 
     -->
-
     <signal name="AllStopped" deprecated="yes">
       <arg name="time" type="t"/>
     </signal>
+    <!-- SigAllStopped:                All Function generators have stopped.
+         @time:                     Time when last function generation ended
+
+         This signal is generated when a function generator stops and all function generators
+         controlled by this master have then stopped. 
+    -->
     <signal name="SigAllStopped">
       <arg name="time" type="T"/>
     </signal>

--- a/interfaces/SoftwareCondition.xml
+++ b/interfaces/SoftwareCondition.xml
@@ -13,7 +13,21 @@
        that the object also implements the general Condition interface.
     -->
   <interface name="de.gsi.saftlib.SoftwareCondition">
-    <!-- Action:    Emitted whenever the condition matches a timing event.
+    <!-- Action:    Deprecated! Use SigAction instead.
+         @event:    The event identifier that matched this rule.
+         @param:    The parameter field, whose meaning depends on the event ID.
+         @deadline: The scheduled execution timestamp of the action (event time + offset).
+         @executed: The actual execution timestamp of the action.
+         @flags:    Whether the action was (ok=0,late=1,early=2,conflict=4,delayed=8)
+      -->
+    <signal name="Action" deprecated="yes">
+      <arg name="event"    type="t"/>
+      <arg name="param"    type="t"/>
+      <arg name="deadline" type="t"/>
+      <arg name="executed" type="t"/>
+      <arg name="flags"    type="q"/>
+    </signal>
+    <!-- SigAction:    Emitted whenever the condition matches a timing event.
          @event:    The event identifier that matched this rule.
          @param:    The parameter field, whose meaning depends on the event ID.
          @deadline: The scheduled execution timestamp of the action (event time + offset).
@@ -30,14 +44,7 @@
          Actions with error flags (late, early, conflict, delayed) are only
          delivered to this signal if the Condition which generated them
          specified that the respective error should be accepted.
-      -->
-    <signal name="Action" deprecated="yes">
-      <arg name="event"    type="t"/>
-      <arg name="param"    type="t"/>
-      <arg name="deadline" type="t"/>
-      <arg name="executed" type="t"/>
-      <arg name="flags"    type="q"/>
-    </signal>
+      -->    
     <signal name="SigAction">
       <arg name="event"    type="t"/>
       <arg name="param"    type="t"/>

--- a/interfaces/TimingReceiver.xml
+++ b/interfaces/TimingReceiver.xml
@@ -70,14 +70,23 @@
       <arg  direction="out" type="i" name="result"/>
     </method>
 
-    <!-- ReadCurrentTime: The current time in nanoseconds since 1970.
+    <!-- ReadCurrentTime: This method is deprecaded, use CurrentTime instead. 
          @result:         Nanoseconds since 1970.
+         The current time in nanoseconds since 1970.
          Due to delays in software, the returned value is probably several
          milliseconds behind the true time.
       -->
     <method name="ReadCurrentTime" deprecated="yes">
       <arg direction="out" type="t" name="result"/>
     </method>
+    <!-- CurrentTime: The current time of the timingreceiver.
+         @result:     the current time of the timingreceiver
+         The result type is saftlib::Time, which can be used to obtain 
+         either the number of nanoseconds since 1970, or the same value
+         minus the current UTC offset.
+         Due to delays in software, the returned value is probably several
+         milliseconds behind the true time.
+      -->
     <method name="CurrentTime">
       <arg direction="out" type="T" name="result"/>
     </method>
@@ -128,11 +137,12 @@
       -->
     <property name="Interfaces" type="a{sa{ss}}" access="read"/>
     
-    <!-- InjectEvent: Simulate the receipt of a timing event.
+    <!-- InjectEvent: The method is depricated, use InjectEvent with saftlib::Time instead.
          @event: The event identifier which is matched against Conditions
          @param: The parameter field, whose meaning depends on the event ID.
          @time:  The execution time for the event, added to condition offsets.
          
+         Simulate the receipt of a timing event
          Sometimes it is useful to simulate the receipt of a timing event. 
          This allows software to test that configured conditions lead to the
          desired behaviour without needing the data master to send anything.
@@ -142,6 +152,16 @@
       <arg direction="in" type="t" name="param"/>
       <arg direction="in" type="t" name="time"/>
     </method>
+    <!-- InjectEvent: Simulate the receipt of a timing event
+
+         @event: The event identifier which is matched against Conditions
+         @param: The parameter field, whose meaning depends on the event ID.
+         @time:  The execution time for the event, added to condition offsets.
+         
+         Sometimes it is useful to simulate the receipt of a timing event. 
+         This allows software to test that configured conditions lead to the
+         desired behaviour without needing the data master to send anything.
+      -->
     <method name="InjectEvent">
       <arg direction="in" type="t" name="event"/>
       <arg direction="in" type="t" name="param"/>

--- a/interfaces/Types.texi
+++ b/interfaces/Types.texi
@@ -10,7 +10,7 @@
 @top Saftlib
 @chapheading Types
 
-The saftlib interfaces documentation uses a number of types which are character encoded. Because Saftlib used DBus in the past, the encoding is similar but not identical to the DBus type encoding. Here is a list of types and its representation in C++ API:
+The saftlib interfaces documentation uses a number of types which are character encoded. Because Saftlib used DBus in the past, the encoding is similar but not identical to the DBus type encoding. The following table lists all types and their representation in the C++ API:
 
 @example 
 y        uint8_t

--- a/interfaces/Types.texi
+++ b/interfaces/Types.texi
@@ -1,0 +1,30 @@
+\input texinfo
+@setfilename Types.info
+@documentencoding us-ascii
+@settitle Saftlib
+@direntry
+* Saftlib: (Types).   Types used in Saftlib interfaces.
+@end direntry
+
+@node Top
+@top Saftlib
+@chapheading Types
+
+The saftlib interfaces documentation uses a number of types which are character encoded. Because Saftlib used DBus in the past, the encoding is similar but not identical to the DBus type encoding. Here is a list of types and its representation in C++ API:
+
+@example 
+y        uint8_t
+b        bool
+n        int16_t
+q        uint16_t
+i        int32_t
+u        uint32_t
+x        int64_t
+t        uint64_t
+d        double
+T        saftlib::Time
+s        std::string
+aX       std::vector<X> where X is can be any type
+a@{KV@}    std::map<K,V> K and V are are key and value types
+
+@bye

--- a/interfaces/WrMilGateway.xml
+++ b/interfaces/WrMilGateway.xml
@@ -4,123 +4,149 @@
   <!-- Include base interfaces -->
   <xi:include href="Owned.xml"/>
   
+  <!-- de.gsi.saftlib.WrMilGateway:
+       @short_description: A converter for WhiteRabbit timing events to MIL.
+     
+       The WhiteRabbit-MIL-Gateway receives WhiteRabbit timing events, translates
+       them into MIL timing events and outputs them with few microsecond accuracy.
+       This device is needed to run SIS18 and ESR.
+    -->  
   <interface name="de.gsi.saftlib.WrMilGateway">
     
-    <!-- Access all registers of the WrMilGateway -->
+    <!-- RegisterContent: Access all registers of the WrMilGateway -->
     <property name="RegisterContent"   type="au" access="read">
     </property>
 
-    <!-- Access MIL event histogram WrMilGateway -->
+    <!-- MilHistogram: Access MIL event histogram WrMilGateway -->
     <property name="MilHistogram"   type="au" access="read">
     </property>
 
-    <!-- WR-MIL magic number -->
+    <!-- WrMilMagic: WR-MIL magic number -->
     <property name="WrMilMagic"   type="u" access="read">
     </property>
 
-    <!-- WR-MIL firmware state -->
+    <!-- FirmwareState: WR-MIL firmware state -->
     <property name="FirmwareState"   type="u" access="read">
     </property>
-    <!-- signal emitted if firmware state changes -->
+    <!-- SigFirmwareState: signal emitted if firmware state changes -->
     <signal name="SigFirmwareState">
       <arg name="state" type="u"/>
     </signal>
 
-    <!-- WR-MIL firmware is active (not stalled) -->
+    <!-- FirmwareRunning: WR-MIL firmware is active (not stalled) -->
     <property name="FirmwareRunning"   type="b" access="read">
     </property>
 
-    <!-- signal emitted if starts/stops running -->
+    <!-- SigFirmwareRunning: signal emitted if starts/stops running -->
     <signal name="SigFirmwareRunning">
       <arg name="running" type="b"/>
     </signal>
 
-    <!-- WR-MIL event source. This can be either 
+    <!-- EventSource: WR-MIL event source. 
+
+         This can be: 
+
          0 -> not configured (default)
+
          1 -> SIS18 (work as SIS18 "Pulszentrale")
+
          2 -> ESR   (work as ESR "Pulszentrale")   -->
     <property name="EventSource"   type="u" access="read">
     </property>
-    <!-- signal emitted if event source changes -->
+    <!-- SigEventSource: signal emitted if event source changes -->
     <signal name="SigEventSource">
       <arg name="source" type="u"/>
     </signal>
 
 
-    <!-- The event number that triggers generation of UTC events -->
+    <!-- UtcTrigger: The event number that triggers generation of UTC events -->
     <property name="UtcTrigger"   type="y" access="readwrite">
     </property>
 
-    <!-- event latency in microseconds. This is the time between the 
-         WR-event deadline and the rising edge at the TIF module caused
-         by the translated MIL event -->
+    <!-- EventLatency: Event latency in microseconds. 
+
+         This is the time between the WR-event deadline and the 
+         rising edge at the TIF module caused by the translated 
+         MIL event -->
     <property name="EventLatency"   type="u" access="readwrite">
     </property>
 
-    <!-- Time between the generated UTC MIL events -->
+    <!-- UtcUtcDelay: Time between the generated UTC MIL events -->
     <property name="UtcUtcDelay"   type="u" access="readwrite">
     </property>
 
-    <!-- Time between the UTC trigger event and the first UTC MIL event -->
+    <!-- TriggerUtcDelay: Time between the UTC trigger event and the first UTC MIL event -->
     <property name="TriggerUtcDelay"   type="u" access="readwrite">
     </property>
 
-    <!-- The number of seconds that is added to the WR-TAI 
+    <!-- UtcOffset: seconds between 01.01.2008 and 01.01.1970
+
+         The number of seconds that is added to the WR-TAI 
          (which starts at 1970) to create a UTC time that  
          starts at 2008 (64bit value) -->
     <property name="UtcOffset"   type="t" access="readwrite">
     </property>
 
 
-    <!-- The number of translated events (as 64bit value) -->
+    <!-- NumMilEvents: The number of translated events (as 64bit value) -->
     <property name="NumMilEvents"   type="t" access="read">
     </property>
 
-    <!-- read a histogram of event delays 
-          [0]: delay < 2^10 ns
-          [1]: delay < 2^11 ns
-          [2]: delay < 2^12 ns
+    <!-- LateHistogram: read a histogram of event delays 
+
+        Bin content:
+
+          [0]: delay less than 2^10 ns
+
+          [1]: delay less than 2^11 ns
+
+          [2]: delay less than 2^12 ns
+
          ...
-         [14]: delay < 2^24 ns
-         [15]: delay < 2^25 ns
+
+         [14]: delay less than 2^24 ns
+
+         [15]: delay less than 2^25 ns
+
     -->
     <property name="LateHistogram"   type="au" access="read">
     </property>
 
 
-    <!-- The number of translated events that were submitted later  
+    <!-- NumLateMilEvents: The number of translated events that were submitted later  
          than the anticipated WR event deadline -->
     <property name="NumLateMilEvents"   type="u" access="read">
     </property>
-    <!-- signal emitted if number of late events increases -->
+    <!-- SigNumLateMilEvents: signal emitted if number of late events increases -->
     <signal name="SigNumLateMilEvents">
       <arg name="total" type="u"/>
       <arg name="since_last_signal" type="u"/>
     </signal>
 
 
+    <!-- InUse: indicates if the gateway is translating any events -->
     <property name="InUse"   type="b" access="read">
     </property>
-    <!-- signal emitted if number of late events increases -->
+    <!-- SigInUse: signal emitted if number of events increases -->
     <signal name="SigInUse">
       <arg name="inUse" type="b"/>
     </signal>
 
 
 
-    <!-- Configure Gateway as SIS18 "Pulszentrale" and start -->
+    <!-- StartSIS18: Configure Gateway as SIS18 "Pulszentrale" and start -->
     <method name="StartSIS18"/>
 
-    <!-- Configure Gateway as ESR "Pulszentrale" and start -->
+    <!-- StartESR: Configure Gateway as ESR "Pulszentrale" and start -->
     <method name="StartESR"/>
 
-    <!-- Reset all event counters and histograms -->
+    <!-- ClearStatistics: Reset all event counters and histograms -->
     <method name="ClearStatistics"/>
 
-    <!-- Stop WR-MIL Gateway and restart after 1 second pause -->
+    <!-- ResetGateway: Stop WR-MIL Gateway and restart after 1 second pause -->
     <method name="ResetGateway"/>
 
-    <!-- Kill WR-MIL Gateway. Only MCU reset can recover (useful to 
+    <!-- KillGateway: Kill WR-MIL Gateway. Only MCU reset can recover (useful to 
          do before loading new firmware)-->
     <method name="KillGateway"/>
 

--- a/interfaces/WrMilGateway.xml
+++ b/interfaces/WrMilGateway.xml
@@ -92,6 +92,10 @@
     <property name="NumMilEvents"   type="t" access="read">
     </property>
 
+    <property name="OpReady"   type="b" access="write">
+    </property>
+
+
     <!-- LateHistogram: read a histogram of event delays 
 
         Bin content:
@@ -149,6 +153,10 @@
     <!-- KillGateway: Kill WR-MIL Gateway. Only MCU reset can recover (useful to 
          do before loading new firmware)-->
     <method name="KillGateway"/>
+
+    <!-- UpdateOLED: causes the OLED screen to be redrawn. only useful if 
+         OP-READY was changed -->
+    <method name="UpdateOLED"/>
 
   </interface>
 </node>

--- a/interfaces/cpp.xsl
+++ b/interfaces/cpp.xsl
@@ -278,7 +278,7 @@
       <xsl:text>  std::shared_ptr&lt;saftbus::ProxyConnection&gt; connection =&#10;</xsl:text>
       <xsl:text>    std::const_pointer_cast&lt;saftbus::ProxyConnection&gt;(get_connection());&#10;</xsl:text>
       <xsl:text>  val =&#10;</xsl:text>
-      <xsl:text>    connection->call_sync(get_object_path(), "org.freedesktop.DBus.Properties", "Get", &#10;</xsl:text>
+      <xsl:text>    connection->call_sync(get_saftbus_index(), get_object_path(), "org.freedesktop.DBus.Properties", "Get", &#10;</xsl:text>
       <xsl:text>      params, get_name());&#10;</xsl:text>
       <xsl:text>}&#10;&#10;</xsl:text>
 
@@ -310,7 +310,7 @@
       <xsl:text>  params.put(std::string(name));&#10;</xsl:text>
       <xsl:text>  params.put(val);&#10;</xsl:text>
       <xsl:text>  std::shared_ptr&lt;saftbus::ProxyConnection&gt; connection = get_connection();&#10;</xsl:text>
-      <xsl:text>  connection->call_sync(get_object_path(), "org.freedesktop.DBus.Properties", "Set",&#10;</xsl:text>
+      <xsl:text>  connection->call_sync(get_saftbus_index(), get_object_path(), "org.freedesktop.DBus.Properties", "Set",&#10;</xsl:text>
       <xsl:text>    params, get_name());&#10;}&#10;&#10;</xsl:text>
 
       <!-- Property setters -->

--- a/interfaces/cpp.xsl
+++ b/interfaces/cpp.xsl
@@ -328,7 +328,7 @@
       </xsl:for-each>
 
       <!-- Receive changed properties -->
-      <xsl:text>void i</xsl:text>
+<!--       <xsl:text>void i</xsl:text>
       <xsl:value-of select="$iface"/>
       <xsl:text>_Proxy::on_properties_changed(&#10;</xsl:text>
       <xsl:text>  const MapChangedProperties&amp; changed_properties,&#10;</xsl:text>
@@ -359,7 +359,7 @@
         <xsl:text>    } else </xsl:text>
       </xsl:for-each>
       <xsl:text> {&#10;      // noop&#10;    }&#10;  }&#10;}&#10;&#10;</xsl:text>
-
+ -->
       <!-- Receive signals -->
       <xsl:text>void i</xsl:text>
       <xsl:value-of select="$iface"/>

--- a/interfaces/h.xsl.in
+++ b/interfaces/h.xsl.in
@@ -351,7 +351,7 @@
       </xsl:for-each>
 
       <!-- Property Signal pointers -->
-      <xsl:text>    // Property signals&#10;</xsl:text>
+<!--       <xsl:text>    // Property signals&#10;</xsl:text>
       <xsl:for-each select="property[@access='read' or @access='readwrite']">
         <xsl:if test="not(annotation[@name = 'org.freedesktop.DBus.Property.EmitsChangedSignal' and @value != 'true'])">
           <xsl:text>    </xsl:text>
@@ -359,7 +359,7 @@
           <xsl:text>;&#10;</xsl:text>
         </xsl:if>
       </xsl:for-each>
-
+ -->
       <!-- Signal pointers -->
       <xsl:text>    // Signals&#10;</xsl:text>
       <xsl:for-each select="signal">
@@ -410,14 +410,14 @@
       <xsl:text>&#10;</xsl:text>
 
       <!-- Property Signal pointers -->
-      <xsl:for-each select="property[@access='read' or @access='readwrite']">
+<!--       <xsl:for-each select="property[@access='read' or @access='readwrite']">
         <xsl:if test="not(annotation[@name = 'org.freedesktop.DBus.Property.EmitsChangedSignal' and @value != 'true'])">
           <xsl:text>    </xsl:text>
           <xsl:call-template name="prop-sigtype"/>
           <xsl:text>;&#10;</xsl:text>
         </xsl:if>
       </xsl:for-each>
-
+ -->
       <!-- Signal pointers -->
       <xsl:for-each select="signal">
         <xsl:text>    </xsl:text>
@@ -439,7 +439,7 @@
 
       <!-- Implementation -->
   protected:
-    void on_properties_changed(const MapChangedProperties&amp; changed_properties, const std::vector&lt; std::string &gt;&amp; invalidated_properties);
+    //void on_properties_changed(const MapChangedProperties&amp; changed_properties, const std::vector&lt; std::string &gt;&amp; invalidated_properties);
     void on_signal(const std::string&amp; sender_name, const std::string&amp; signal_name, const saftbus::Serial&amp; parameters);
     void fetch_property(const char* name, saftbus::Serial&amp; val) const;
     void update_property(const char* name, const saftbus::Serial&amp; val);

--- a/saftbus/Connection.cpp
+++ b/saftbus/Connection.cpp
@@ -449,6 +449,16 @@ bool Connection::dispatch(Slib::IOCondition condition, Socket *socket)
 					logger.add(dt).add(" us\n");
 				}
 				break;
+				case saftbus::GET_SAFTBUS_INDEX: 
+				{
+					saftbus::Timer f_time(_function_run_times["Connection::GET_SAFTBUS_INDEX"]);
+					logger.add("     GET_SAFTBUS_INDEX received: ");
+					std::string object_path, interface_name;
+					saftbus::read(socket->get_fd(), object_path);
+					saftbus::read(socket->get_fd(), interface_name);
+					saftbus::write(socket->get_fd(), _saftbus_indices[interface_name][object_path]);
+				}
+				break;
 				case saftbus::SIGNAL_FD: 
 				{
 					// each Proxy constructor will send the reading end of a pipe

--- a/saftbus/Connection.cpp
+++ b/saftbus/Connection.cpp
@@ -567,7 +567,7 @@ bool Connection::dispatch(Slib::IOCondition condition, Socket *socket)
 				
 						// saftbus object lookup
 						int index = _saftbus_indices[derived_interface_name][object_path];
-						if (index == 0) {// == not found
+						if (index == 0 || index != saftbus_index) {// == not found or wrong check index
 							// this causes an exception on the proxy side
 							std::string what("unknown object path: ");
 							what.append(object_path);
@@ -635,7 +635,7 @@ bool Connection::dispatch(Slib::IOCondition condition, Socket *socket)
 
 						// saftbus object lookup
 						int index = _saftbus_indices[interface_name][object_path];
-						if (index == 0) {// == not found
+						if (index == 0 || index != saftbus_index) {// == not found
 							// this causes an exception on the proxy side
 							std::string what("unknown object path: ");
 							what.append(object_path);

--- a/saftbus/Connection.cpp
+++ b/saftbus/Connection.cpp
@@ -532,6 +532,7 @@ bool Connection::dispatch(Slib::IOCondition condition, Socket *socket)
 					saftbus::read_all(socket->get_fd(), &payload.data()[0], size);
 
 					// saftbus::Serial to get content
+					int saftbus_index;
 					std::string object_path;
 					std::string sender;
 					std::string interface_name;
@@ -539,6 +540,7 @@ bool Connection::dispatch(Slib::IOCondition condition, Socket *socket)
 					Serial parameters;
 
 					payload.get_init();
+					payload.get(saftbus_index);
 					payload.get(object_path);
 					payload.get(sender);
 					payload.get(interface_name);

--- a/saftbus/Connection.cpp
+++ b/saftbus/Connection.cpp
@@ -496,24 +496,29 @@ bool Connection::dispatch(Slib::IOCondition condition, Socket *socket)
 					saftbus::Timer f_time(_function_run_times["Connection::dispatch_SIGNAL_REMOVE_FD"]);
 
 					logger.add("           SIGNAL_REMOVE_FD received: ");
+					int saftbus_index;
 					std::string name, object_path, interface_name;
 					int proxy_id;
+					saftbus::read(socket->get_fd(), saftbus_index);
 					saftbus::read(socket->get_fd(), object_path);
 					saftbus::read(socket->get_fd(), interface_name);
 					saftbus::read(socket->get_fd(), proxy_id);
 
 					ProxyPipe pp;
 					pp.id = proxy_id;
-					auto pp_done = _proxy_pipes[interface_name][object_path].find(pp);
-					close(pp_done->fd);
 					logger.add("for object_path=").add(object_path)
 					      .add(" interface_name=").add(interface_name)
-					      .add(" proxy_id=").add(proxy_id)
-					      .add(" fd=").add(pp_done->fd).add("\n");
-					_proxy_pipes[interface_name][object_path].erase(pp_done);
+					      .add(" proxy_id=").add(proxy_id);
 
-					proxy_pipe_garbage_collection();
-
+					if (saftbus_index == _saftbus_indices[interface_name][object_path]) {
+						auto pp_done = _proxy_pipes[interface_name][object_path].find(pp);
+						close(pp_done->fd);
+					    logger.add(" fd=").add(pp_done->fd).add("\n");
+						_proxy_pipes[interface_name][object_path].erase(pp_done);
+						proxy_pipe_garbage_collection();
+					} else {
+						logger.add(" ==> NOT removing signal pipe because saftbus object under this object_path changed since proxy creation!\n");
+					}
 				}
 				break;
 				case saftbus::METHOD_CALL: 
@@ -569,7 +574,12 @@ bool Connection::dispatch(Slib::IOCondition condition, Socket *socket)
 						int index = _saftbus_indices[derived_interface_name][object_path];
 						if (index == 0 || index != saftbus_index) {// == not found or wrong check index
 							// this causes an exception on the proxy side
-							std::string what("unknown object path: ");
+							std::string what;
+							if (index == 0) {
+								what.append("unknown object path: ");
+							} else {
+								what.append("saftbus object under this object path has changed since Proxy creation: ");
+							}
 							what.append(object_path);
 							saftbus::write(socket->get_fd(), saftbus::METHOD_ERROR);
 							saftbus::write(socket->get_fd(), saftbus::Error::FAILED);
@@ -637,7 +647,12 @@ bool Connection::dispatch(Slib::IOCondition condition, Socket *socket)
 						int index = _saftbus_indices[interface_name][object_path];
 						if (index == 0 || index != saftbus_index) {// == not found
 							// this causes an exception on the proxy side
-							std::string what("unknown object path: ");
+							std::string what;
+							if (index == 0) {
+								what.append("unknown object path: ");
+							} else {
+								what.append("saftbus object under this object path has changed since Proxy creation: ");
+							}
 							what.append(object_path);
 							saftbus::write(socket->get_fd(), saftbus::METHOD_ERROR);
 							saftbus::write(socket->get_fd(), saftbus::Error::FAILED);

--- a/saftbus/Proxy.cpp
+++ b/saftbus/Proxy.cpp
@@ -253,7 +253,9 @@ const Serial& Proxy::call_sync(std::string function_name, const Serial &query)
 	// 	                                      query)).get_child(0));
 	// return _result;
 
-	const Serial &result = _connection->call_sync(_object_path, 
+	const Serial &result = _connection->call_sync(
+		                          _saftbus_index, 
+		                          _object_path, 
 		                          _interface_name,
 		                          function_name,
 		                          query);

--- a/saftbus/Proxy.cpp
+++ b/saftbus/Proxy.cpp
@@ -44,7 +44,7 @@ Proxy::Proxy(saftbus::BusType  	   bus_type,
 	}
 
 	_saftbus_index = _connection->get_saftbus_index(object_path, interface_name);
-	std::cerr << "saftbus index of objec: " << _saftbus_index << std::endl;
+	// std::cerr << "saftbus index of objec: " << _saftbus_index << std::endl;
 
 	// create a pipe through which we will receive signals from the saftd
 	if (&signalGroup != &saftlib::noSignals) {
@@ -83,7 +83,7 @@ Proxy::~Proxy()
 
 	// free all resources ...
 	try {
-		_connection->remove_proxy_signal_fd(_object_path, _interface_name, _global_id);
+		_connection->remove_proxy_signal_fd(_saftbus_index, _object_path, _interface_name, _global_id);
 		close(_pipe_fd[0]);
 		close(_pipe_fd[1]);
 	} catch(std::exception &e) {

--- a/saftbus/Proxy.h
+++ b/saftbus/Proxy.h
@@ -55,6 +55,7 @@ namespace saftbus
 
 		std::string get_object_path() const;
 		std::string get_name() const;
+		int get_saftbus_index() const;
 
 		const Serial& call_sync(std::string function_name, const Serial &query);
 
@@ -75,6 +76,8 @@ namespace saftbus
 		std::string _name;
 		std::string _object_path;
 		std::string _interface_name;
+		int         _saftbus_index;      // this is requested from the server connection 
+		                                 // during proxy construction.
 
 
 		Serial            _call_sync_result;

--- a/saftbus/ProxyConnection.cpp
+++ b/saftbus/ProxyConnection.cpp
@@ -68,6 +68,18 @@ ProxyConnection::ProxyConnection(const std::string &base_name)
 	}
 }
 
+int ProxyConnection::get_saftbus_index(const std::string &object_path, const std::string &interface_name)
+{
+	std::unique_lock<std::mutex> lock(_socket_mutex);
+	saftbus::write(get_fd(), saftbus::GET_SAFTBUS_INDEX);
+	saftbus::write(get_fd(), object_path);
+	saftbus::write(get_fd(), interface_name);
+	int saftbus_index = -1;
+	saftbus::read(get_fd(), saftbus_index);
+	return saftbus_index;
+}
+
+
 int ProxyConnection::get_connection_id()
 {
 	std::unique_lock<std::mutex> lock(_socket_mutex);

--- a/saftbus/ProxyConnection.cpp
+++ b/saftbus/ProxyConnection.cpp
@@ -117,7 +117,8 @@ void ProxyConnection::remove_proxy_signal_fd(std::string object_path,
 	saftbus::write(get_fd(), global_id);
 }
 
-Serial& ProxyConnection::call_sync (const std::string& object_path, 
+Serial& ProxyConnection::call_sync (int saftbus_index,
+	                                const std::string& object_path, 
 	                                const std::string& interface_name, 
 	                                const std::string& name, 
 	                                const Serial& parameters, 
@@ -142,6 +143,7 @@ Serial& ProxyConnection::call_sync (const std::string& object_path,
 	//                                            << name << ")" << std::endl;
 
 	Serial message;
+	message.put(saftbus_index);
 	message.put(object_path);
 	message.put(_saftbus_id);
 	message.put(interface_name);

--- a/saftbus/ProxyConnection.cpp
+++ b/saftbus/ProxyConnection.cpp
@@ -106,12 +106,14 @@ void ProxyConnection::send_proxy_signal_fd(int pipe_fd,
 	saftbus::write(get_fd(), global_id);
 }
 
-void ProxyConnection::remove_proxy_signal_fd(std::string object_path,
+void ProxyConnection::remove_proxy_signal_fd(int saftbus_index,
+			                                 std::string object_path,
 	                                         std::string interface_name,
 	                                         int global_id) 
 {
 	std::unique_lock<std::mutex> lock(_socket_mutex);
 	saftbus::write(get_fd(), saftbus::SIGNAL_REMOVE_FD);
+	saftbus::write(get_fd(), saftbus_index);
 	saftbus::write(get_fd(), object_path);
 	saftbus::write(get_fd(), interface_name);
 	saftbus::write(get_fd(), global_id);

--- a/saftbus/ProxyConnection.h
+++ b/saftbus/ProxyConnection.h
@@ -56,6 +56,8 @@ namespace saftbus
 		std::string get_saftbus_id() { return _saftbus_id; }
 		int get_connection_id();
 
+		int get_saftbus_index(const std::string &object_path, const std::string &interface_name);
+
 		// returned fd should only be used with a lock or in single threaded environments
 		int get_fd() const {return _create_socket; }
 	private:

--- a/saftbus/ProxyConnection.h
+++ b/saftbus/ProxyConnection.h
@@ -50,7 +50,8 @@ namespace saftbus
                                   std::string object_path,
                                   std::string interface_name,
                                   int global_id);
-		void remove_proxy_signal_fd(std::string object_path,
+		void remove_proxy_signal_fd(int saftbus_index,
+			                        std::string object_path,
                                     std::string interface_name,
                                     int global_id) ;
 

--- a/saftbus/ProxyConnection.h
+++ b/saftbus/ProxyConnection.h
@@ -35,7 +35,8 @@ namespace saftbus
 		using SlotSignal = sigc::slot<void, const std::shared_ptr<ProxyConnection>&, const std::string&, const std::string&, const std::string&, const std::string&, const Serial&>;
 
 		// is used by Proxies to fetch properties
-		Serial& call_sync(const std::string& object_path, 
+		Serial& call_sync(int saftbus_index,
+			              const std::string& object_path, 
 						  const std::string& interface_name, 
 						  const std::string& method_name, 
 						  const Serial& parameters, 

--- a/saftbus/Socket.cpp
+++ b/saftbus/Socket.cpp
@@ -4,11 +4,10 @@
 #include <iostream>
 #include <utility>
 #include <time.h>
+#include <sys/stat.h>
 
 //#include "giomm.h"
 #include "core.h"
-
-
 
 namespace saftbus
 {
@@ -31,6 +30,9 @@ void Socket::wait_for_client()
 		if (_debug_level > 5) std::cerr << "port busy" << std::endl;
 		throw std::runtime_error("port busy");
 	}
+	chmod(_filename.c_str(), S_IRUSR | S_IWUSR | S_IXUSR | 
+		                     S_IRGRP | S_IWGRP | S_IXGRP | 
+		                     S_IROTH | S_IWOTH | S_IXOTH);
 	listen(_create_socket, 1);
 	//_addrlen = sizeof(struct sockaddr_in);
 	// the connection will wait for incoming calls

--- a/saftbus/saftbus-ctl.cpp
+++ b/saftbus/saftbus-ctl.cpp
@@ -374,7 +374,8 @@ void saftbus_get_property(const std::string& interface_name,
 	params.put(interface_name);
 	params.put(property_name);
 
-	saftbus::Serial val = connection.call_sync(object_path, "org.freedesktop.DBus.Properties", "Get", 
+	int saftbus_index = connection.get_saftbus_index(object_path, interface_name);
+	saftbus::Serial val = connection.call_sync(saftbus_index, object_path, "org.freedesktop.DBus.Properties", "Get", 
 	  params, "sender");
 
 	val.get_init();
@@ -439,7 +440,8 @@ void saftbus_set_property(const std::string& interface_name,
 	params.put(property_value);
 
 
-	saftbus::Serial val = connection.call_sync(object_path, "org.freedesktop.DBus.Properties", "Set", 
+	int saftbus_index = connection.get_saftbus_index(object_path, interface_name);
+	saftbus::Serial val = connection.call_sync(saftbus_index, object_path, "org.freedesktop.DBus.Properties", "Set", 
 	  params, "sender");
 } 
 
@@ -468,7 +470,8 @@ void saftbus_method_call (const std::string& interface_name,
 		else if (type_signature[i] == 's') { std::string   value; value_in >> value; args.put(value); }
 		else {std::cerr << "unknow type signature for method call " ; return; }
 	}
-	saftbus::Serial val = connection.call_sync(object_path, interface_name, method_name, args, "sender");
+	int saftbus_index = connection.get_saftbus_index(object_path, interface_name);
+	saftbus::Serial val = connection.call_sync(saftbus_index, object_path, interface_name, method_name, args, "sender");
 
 	val.get_init();
 	if (return_type_signature == "a{sa{ss}}") { print_serial_map_map<std::string,std::string,std::string>(val); }

--- a/saftbus/saftbus.h
+++ b/saftbus/saftbus.h
@@ -66,6 +66,8 @@ namespace saftbus
 		SAFTBUS_CTL_GET_STATE, 
 		SAFTBUS_CTL_ENABLE_LOGGING,
 		SAFTBUS_CTL_DISABLE_LOGGING,
+
+		GET_SAFTBUS_INDEX,
 	};
 
 	// bool deserialize(Glib::Variant<std::vector<Glib::VariantBase> > &result, const char *data, gsize size);

--- a/saftcommon/Time.h
+++ b/saftcommon/Time.h
@@ -181,7 +181,7 @@ namespace saftlib
 			return TAI_is_UTCleap(TAI);
 		}
 
-		friend Time makeTimeUTC(uint64_t UTC, bool isLeap = false);
+		friend Time makeTimeUTC(uint64_t UTC, bool isLeap);
 		friend Time makeTimeTAI(uint64_t TAI);
 	private:
 		explicit Time(const uint64_t& value) : TAI(value) {
@@ -194,7 +194,7 @@ namespace saftlib
 	Time operator-(const Time& lhs, const int64_t& rhs);
 	Time operator+(const int64_t& lhs, const Time& rhs);
 	Time operator-(const int64_t& lhs, const Time& rhs);
-	Time makeTimeUTC(uint64_t UTC, bool isLeap);
+	Time makeTimeUTC(uint64_t UTC, bool isLeap = false);
 	Time makeTimeTAI(uint64_t TAI);
 
 

--- a/saftlib.pc.in
+++ b/saftlib.pc.in
@@ -7,5 +7,5 @@ Name: saftlib
 Description: Simplified API for Timing
 Version: @VERSION@
 Requires: sigc++-2.0 >= 0.27.1
-Libs: -L${libdir} -lsaftlib -lsaftbus
+Libs: -L${libdir} -lsaftlib -lsaftbus -lsaftcommon
 Cflags: -I${includedir}

--- a/src/SAFTd.cpp
+++ b/src/SAFTd.cpp
@@ -147,8 +147,6 @@ std::string SAFTd::AttachDevice(const std::string& name, const std::string& path
       Drivers::probe(od);
       if (od.ref) {
         devs.insert(std::make_pair(name, od));
-        // inform clients of updated property
-        //Devices(getDevices());
         return od.objectPath;
       } else {
         throw saftbus::Error(saftbus::Error::INVALID_ARGS, "no driver available for this device");
@@ -173,9 +171,6 @@ void SAFTd::RemoveDevice(const std::string& name)
   elem->second.ref.reset();
   elem->second.device.close();
   devs.erase(elem);
-  
-  // inform clients of updated property 
-  //Devices(getDevices());
 }
 
 std::string SAFTd::getSourceVersion() const

--- a/src/SAFTd.cpp
+++ b/src/SAFTd.cpp
@@ -148,7 +148,7 @@ std::string SAFTd::AttachDevice(const std::string& name, const std::string& path
       if (od.ref) {
         devs.insert(std::make_pair(name, od));
         // inform clients of updated property
-        Devices(getDevices());
+        //Devices(getDevices());
         return od.objectPath;
       } else {
         throw saftbus::Error(saftbus::Error::INVALID_ARGS, "no driver available for this device");
@@ -175,7 +175,7 @@ void SAFTd::RemoveDevice(const std::string& name)
   devs.erase(elem);
   
   // inform clients of updated property 
-  Devices(getDevices());
+  //Devices(getDevices());
 }
 
 std::string SAFTd::getSourceVersion() const


### PR DESCRIPTION
- safely rescan channels
- fix a MSI resource leak in MasterFunctionGenerator driver
- disallow simultaneous use of MasterFG and individual channels
- Proxies detect if their referenced object in saftd has been removed
- this branch also contains the pdf-doc fix