### PR TITLE
fg-firmware: rescan wait until firmware is finished

### DIFF
--- a/drivers/FunctionGeneratorFirmware.cpp
+++ b/drivers/FunctionGeneratorFirmware.cpp
@@ -86,9 +86,14 @@ FunctionGeneratorFirmware::FunctionGeneratorFirmware(const ConstructorType& args
     }
 
     if (!have_fg_firmware) throw saftbus::Error(saftbus::Error::FAILED, "no FunctionGeneratorFirmware found");
-    clog << kLogDebug << " WR-MIL-Gateway found" << std::endl;
 
-    Scan(); // do the initial scan
+    try {
+      Scan(); // do the initial scan. If there's a timeout here, the 
+              //  FunctionGeneratorFirmware driver should still be loaded 
+              //  that's why this is in a try catch block
+    } catch (saftbus::Error &e) {
+      clog << kLogDebug << "Scan FG-channels timeout" << std::endl;
+    }
 }
 
 FunctionGeneratorFirmware::~FunctionGeneratorFirmware()
@@ -132,6 +137,26 @@ std::map<std::string, std::string> FunctionGeneratorFirmware::Scan()
   return ScanMasterFg();
 }
 
+void FunctionGeneratorFirmware::firmware_rescan(eb_address_t swi)
+{
+  // initiate firmware rescan and wait until firmware is done 
+  tr->getDevice().write(fgb + SHM_BASE + FG_SCAN_DONE, EB_DATA32, 1);
+  tr->getDevice().write(swi, EB_DATA32, SWI_SCAN);
+  // wait until firmware is done scanning
+  for (int i = 0;; ++i) {
+    eb_data_t done; 
+    tr->getDevice().read(fgb + SHM_BASE + FG_SCAN_DONE, EB_DATA32, &done);
+    if (done==0) {
+      break;
+    }
+    if (i == 200) { // wait at least 20 seconds before timeout
+      throw saftbus::Error(saftbus::Error(saftbus::Error::FAILED,"timeout while waiting for fg-firmware scan"));
+    }
+    usleep(100000); // 100 ms 
+  }
+}
+
+
 // pass sigc signals from impl class to dbus
 // to reduce traffic only generate signals if we have an owner
 std::map<std::string, std::string> FunctionGeneratorFirmware::ScanMasterFg()
@@ -163,9 +188,8 @@ std::map<std::string, std::string> FunctionGeneratorFirmware::ScanMasterFg()
     clog << kLogDebug << "mailbox address for swi is 0x" << std::hex << swi << std::endl;
     eb_data_t num_channels, buffer_size, macros[FG_MACROS_SIZE];
     
-    tr->getDevice().write(swi, EB_DATA32, SWI_SCAN);
-    sleep(1); // this is to make sure that scanning is done when we proceed.
-              //   -> should be replaced by an MSI from the LM32 in the future.
+    // firmware scan and wait until it is done
+    firmware_rescan(swi);
 
     // Probe the configuration and hardware macros
     cycle.open(device);
@@ -248,9 +272,8 @@ std::map<std::string, std::string> FunctionGeneratorFirmware::ScanFgChannels()
     clog << kLogDebug << "mailbox address for swi is 0x" << std::hex << swi << std::endl;
     eb_data_t num_channels, buffer_size, macros[FG_MACROS_SIZE];
     
-    tr->getDevice().write(swi, EB_DATA32, SWI_SCAN);
-    sleep(1); // this is to make sure that scanning is done when we proceed.
-              //   -> should be replaced by an MSI from the LM32 in the future.
+    // firmware scan and wait until it is done
+    firmware_rescan(swi);
 
     // Probe the configuration and hardware macros
     cycle.open(device);

--- a/drivers/FunctionGeneratorFirmware.h
+++ b/drivers/FunctionGeneratorFirmware.h
@@ -69,6 +69,8 @@ class FunctionGeneratorFirmware : public Owned, public iFunctionGeneratorFirmwar
     FunctionGeneratorFirmware(const ConstructorType& args);
     ~FunctionGeneratorFirmware();
 
+    void firmware_rescan(eb_address_t swi);
+
     bool nothing_runs();
 
     std::string                objectPath;

--- a/drivers/TimingReceiver.cpp
+++ b/drivers/TimingReceiver.cpp
@@ -864,7 +864,7 @@ void TimingReceiver::probe(OpenDevice& od)
       clog << kLogDebug << "TimingReceiver: FunctionGenerator firmware found" << std::endl;
     } catch (saftbus::Error &e) {
       // send log message if firmware was not found ?
-      clog << kLogDebug << "TimingReceiver: no FunctionGenerator firmware found" << std::endl;
+      //clog << kLogDebug << "TimingReceiver: no FunctionGenerator firmware found" << std::endl;
     }
 
    
@@ -879,7 +879,7 @@ void TimingReceiver::probe(OpenDevice& od)
       clog << kLogDebug << "TimingReceiver: WR-MIL-Gateway firmware found" << std::endl;
     } catch (saftbus::Error &e) {
       // send log message if firmware was not found ?
-      clog << kLogDebug << "TimingReceiver: no WR-MIL-Gateway firmware found" << std::endl;
+      //clog << kLogDebug << "TimingReceiver: no WR-MIL-Gateway firmware found" << std::endl;
     }
 
 

--- a/drivers/fg_regs.h
+++ b/drivers/fg_regs.h
@@ -33,54 +33,57 @@
 #define MSI_MAILBOX_PRODUCT       0xfab0bdd8
 
 // Shared memory base address
-#define SHM_BASE	        0x500
-#define BOARD_ID	        0x0	// 64-bit
-#define EXT_ID		        0x8	// 64-bit
-#define BACKPLANE_ID	    0x10	// 64-bit
-#define BOARD_TEMP	      0x18	// 32-bit ...
-#define EXT_TEMP	        0x1c
-#define BACKPLACE_TEMP	  0x20
-#define FG_MAGIC_NUMBER	  0x24	// 0xdeadbeef
-#define FG_VERSION	      0x28	// expect v3
-#define FG_MB_SLOT	      0x2c	// mb slot for host=>lm32
-#define FG_NUM_CHANNELS	  0x30
-#define FG_BUFFER_SIZE	  0x34
-#define FG_MACROS	        0x38	// 256 entries of (hi..lo): slot, device, version, output-bits
+#define SHM_BASE          0x500
+#define BOARD_ID          0x0   // 64-bit
+#define EXT_ID            0x8   // 64-bit
+#define BACKPLANE_ID      0x10  // 64-bit
+#define BOARD_TEMP        0x18  // 32-bit ...
+#define EXT_TEMP          0x1c
+#define BACKPLACE_TEMP    0x20
+#define FG_MAGIC_NUMBER   0x24  // 0xdeadbeef
+#define FG_VERSION        0x28  // expect v3
+#define FG_MB_SLOT        0x2c  // mb slot for host=>lm32
+#define FG_NUM_CHANNELS   0x30
+#define FG_BUFFER_SIZE    0x34
+#define FG_MACROS         0x38  // 256 entries of (hi..lo): slot, device, version, output-bits
+#define FG_SCAN_DONE      0x100c0  // firmware writes 0 here if scan of channels is done
 
-#define FG_MACROS_SIZE	256
+#define FG_MACROS_SIZE  256
 
-#define FG_REGS_BASE_	0x438	// FG_MACROS + 4 * 256 + 4
-#define FG_WPTR		    0x0
-#define FG_RPTR		    0x4
-#define FG_MBX_SLOT		0x8
-#define FG_MACRO_NUM	0xc
-#define FG_RAMP_COUNT	0x10
-#define FG_TAG		    0x14
-#define FG_STATE	    0x18
-#define FG_REGS_SIZE	0x1c
+#define FG_REGS_BASE_   0x438   // FG_MACROS + 4 * 256 + 4
+#define FG_WPTR         0x0
+#define FG_RPTR         0x4
+#define FG_MBX_SLOT     0x8
+#define FG_MACRO_NUM    0xc
+#define FG_RAMP_COUNT   0x10
+#define FG_TAG          0x14
+#define FG_STATE        0x18
+#define FG_REGS_SIZE    0x1c
 
 // channel, num_channels
 #define FG_REGS_BASE(c,n) (FG_REGS_BASE_+FG_REGS_SIZE*c)
 
-#define PARAM_COEFF_AB	0x0	// high = coeff_a
-#define PARAM_COEFF_C	  0x4
-#define PARAM_CONTROL	  0x8	// 2..0=step, 5..3=freq, 11..6=shift_b, 17..12=shifta
-#define PARAM_SIZE	    0xc
+#define PARAM_COEFF_AB  0x0 // high = coeff_a
+#define PARAM_COEFF_C   0x4
+#define PARAM_CONTROL   0x8   // 2..0=step, 5..3=freq, 11..6=shift_b, 17..12=shifta
+#define PARAM_SIZE      0xc
 
 // channel, index, num_channels, buffer_size
 #define FG_BUFF_BASE(c,i,n,s) (FG_REGS_BASE(n,n)+(i+c*s)*PARAM_SIZE)
 
+
 // Software interrupt numbers; host=>lm32
-#define SWI_ENABLE	0x00020000UL
-#define SWI_DISABLE	0x00030000UL
+#define SWI_ENABLE  0x00020000UL
+#define SWI_DISABLE 0x00030000UL
 #define SWI_SCAN    0x00040000UL // cause firmware to scan all busses for fg channels
 
 // interrupt payload; lm32=>host
 #define IRQ_DAT_REFILL          0
-#define IRQ_DAT_START		        1
-#define IRQ_DAT_STOP_EMPTY	    2
-#define IRQ_DAT_STOP_NOT_EMPTY	3
-#define IRQ_DAT_ARMED		        4
-#define IRQ_DAT_DISARMED	      5
+#define IRQ_DAT_START           1
+#define IRQ_DAT_STOP_EMPTY      2
+#define IRQ_DAT_STOP_NOT_EMPTY  3
+#define IRQ_DAT_ARMED           4
+#define IRQ_DAT_DISARMED        5
+
 
 #endif

--- a/src/saft-fg-ctl.cpp
+++ b/src/saft-fg-ctl.cpp
@@ -139,7 +139,7 @@ int main(int argc, char** argv)
     bool repeat = false;
     bool generate = false;
     bool scan = false; 
-    char i_or_m;
+    char i_or_m = 'x';
     
     // Process command-line
     int opt, error = 0;


### PR DESCRIPTION
Change the behaviour of Methods FunctionGeneratorFirmware::Scan**() such that they block until the LM32-firmware is done scanning all the busses. After a 20s timeout an exception is thrown. 
The old behaviour (block for a fixed time of 1s) was not good and failed in some cases.

This needs the latest LM32-firmware changes to work