### PR TITLE
Flag bpc start

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Set these variables before each release:
 m4_define(MAJOR,2)    dnl Increment if removed/changed properties/signals/methods since previous release
-m4_define(MINOR,1)    dnl Increment if added properties/signals/methods; reset to 0 if MAJOR changed
-m4_define(REVISION,2) dnl Increment on each release; reset to 0 if MAJOR/MINOR changed
+m4_define(MINOR,2)    dnl Increment if added properties/signals/methods; reset to 0 if MAJOR changed
+m4_define(REVISION,0) dnl Increment on each release; reset to 0 if MAJOR/MINOR changed
 m4_define(SONAME,4)   dnl Whenever MAJOR is incremented, add MINOR+1 to this variable
 
 AC_PREREQ(2.63)

--- a/saftcommon/CommonFunctions.cpp
+++ b/saftcommon/CommonFunctions.cpp
@@ -73,7 +73,10 @@ std::string tr_formatActionEvent(uint64_t id, uint32_t pmode)
       full << " SID: "   << fmt << std::setw(4) << ((id >> 20) & 0xfff);
       full << " BPID: "  << fmt << std::setw(5) << ((id >> 6) & 0x3fff);
       full << " RES: "   << fmt << std::setw(4) << (id & 0x3f);
-    } // if fid==0
+    } // if fid==1
+    else {
+      full << " Other: " << fmt << std::setw(9) << (id & 0xfffffffff);
+    }
   }
   else full << " EvtID: " << fmt << std::setw(width) << std::setfill('0') << id;
   

--- a/saftcommon/CommonFunctions.cpp
+++ b/saftcommon/CommonFunctions.cpp
@@ -70,6 +70,7 @@ std::string tr_formatActionEvent(uint64_t id, uint32_t pmode)
     } // if fid==0
     if (fid == 1) {
       full << " FLAGS: " << fmt << std::setw(1) << ((id >> 32) & 0xf);
+      full << " BPC: "   << fmt << std::setw(1) << ((id >> 34) & 0x1);
       full << " SID: "   << fmt << std::setw(4) << ((id >> 20) & 0xfff);
       full << " BPID: "  << fmt << std::setw(5) << ((id >> 6) & 0x3fff);
       full << " RES: "   << fmt << std::setw(4) << (id & 0x3f);

--- a/saftcommon/CommonFunctions.cpp
+++ b/saftcommon/CommonFunctions.cpp
@@ -85,7 +85,7 @@ std::string tr_formatActionEvent(uint64_t id, uint32_t pmode)
       full << " BPID: "  << fmt << std::setw(5) << ((id >> 10) & 0x3fff);
       full << " RES: "   << fmt << std::setw(4) << (id & 0x3ff);
     } // if fid==0
-    if (fid == 1) {
+    else if (fid == 1) {
       full << " FLAGS: " << fmt << std::setw(1) << ((id >> 32) & 0xf);
       full << " BPC: "   << fmt << std::setw(1) << ((id >> 34) & 0x1);
       full << " SID: "   << fmt << std::setw(4) << ((id >> 20) & 0xfff);

--- a/src/saft-ctl.cpp
+++ b/src/saft-ctl.cpp
@@ -262,7 +262,7 @@ int main(int argc, char** argv)
 
   // variables inject event
   uint64_t eventID     = 0x0;     // full 64 bit EventID contained in the timing message
-  uint64_t eventParam  = 0x0;     // full 64 bit parameter contained in the tming message
+  uint64_t eventParam  = 0x0;     // full 64 bit parameter contained in the timing message
   uint64_t eventTNext  = 0x0;     // time for next event (this value is added to the current time or the next PPS, see option -p
   saftlib::Time eventTime;     // time for next event in PTP time
   saftlib::Time ppsNext;     // time for next PPS 

--- a/src/saft-ctl.cpp
+++ b/src/saft-ctl.cpp
@@ -474,7 +474,7 @@ int main(int argc, char** argv)
       // exit the program in a second thread, because the main 
       // thread will be stuck waiting for the response from saftd
       // which will never be sent after calling the quit() method
-      std::thread t( [](){sleep(1);exit(1);} );
+      std::thread t( [](){usleep(100000);exit(1);} );
       saftd->Quit();
       t.join();
     }


### PR DESCRIPTION
With saft-ctl snoop show the BPC start flag (part of the 4 reserved flags).
If FID is not 0,1 show the unknown part of the ID as 'Other'.