### PR TITLE
Fix eb fwd on rpi

### DIFF
--- a/src/SAFTd.cpp
+++ b/src/SAFTd.cpp
@@ -193,11 +193,14 @@ void SAFTd::RemoveDevice(const std::string& name)
 
 std::string SAFTd::EbForward(const std::string& saftlib_device)
 {
-  std::cerr << "SAFTd::EbForward(" << saftlib_device << ") called" << std::endl;
   if (m_eb_forward.find(saftlib_device) != m_eb_forward.end()) {
     return m_eb_forward[saftlib_device]->saft_eb_devide().substr(1);
   }
-  return std::string("non-forwarded-device");
+  auto od = devs.find(saftlib_device);
+  if (od != devs.end()) {
+    return od->second.etherbonePath;
+  }
+  throw saftbus::Error(saftbus::Error::INVALID_ARGS, "device " + saftlib_device + " unknown");
 }
 
 

--- a/src/eb-forward.cpp
+++ b/src/eb-forward.cpp
@@ -69,7 +69,7 @@ namespace saftlib {
 					if (request[0]     == 0x4e && // test for Etherbone magic word
 						request[1]     == 0x6f &&
 						request[2]     == 0x11 &&
-						request[3]     == 0xff) 
+						(request[3]     == 0xff || request[3] == 0x77)) 
 					{
 						response.push_back(0x4e);
 						response.push_back(0x6f);
@@ -159,11 +159,10 @@ namespace saftlib {
 		}
 	}
 
-
 	std::string EB_Forward::saft_eb_devide()
 	{
 		return std::string(ptsname(_pts_fd));
 	}
 
-
 }
+

--- a/src/eb-forward.cpp
+++ b/src/eb-forward.cpp
@@ -69,8 +69,9 @@ namespace saftlib {
 					if (request[0]     == 0x4e && // test for Etherbone magic word
 						request[1]     == 0x6f &&
 						request[2]     == 0x11 &&
-						(request[3]     == 0xff || request[3] == 0x77)) 
+						(request[3]     == 0xff || request[3] == 0x77)) // on 32 bit systems, the host will send 0x77 while on 64 bit systems the host will send 0xff
 					{
+						// hard-coded response
 						response.push_back(0x4e);
 						response.push_back(0x6f);
 						response.push_back(0x16);


### PR DESCRIPTION
fix: saft-eb-fwd works on 32-bit systems
improvement: "saft-eb-fwd tr0" outputs etherbone device name if tr0 is not forwarded (e.g. dev/wbm0)