### PR TITLE
run saft-testbench in script phase of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,8 @@ before_script:
 - make driver
 - sudo make install
 
-# make and install saftlib
+# make and install saftlib and run the testbench
 script:
 - make saftlib -j$(nproc)
-
-after_success:
 - sudo make saftlib-install
-- saft-testbench
+- SAFTBUS_SOCKET_PATH=`pwd`/saftbus_socket LD_LIBRARY_PATH=/usr/local/lib saft-testbench


### PR DESCRIPTION
If the testbench is run in the after_success phase of .travis.yml, the testbench failure will not be reported as failure