### PR TITLE
driver: add missing else

### DIFF
--- a/drivers/InoutImpl.cpp
+++ b/drivers/InoutImpl.cpp
@@ -101,8 +101,8 @@ bool InoutImpl::ReadCombinedOutput()
   unsigned totalInputs = 0;
 
   cycle.open(tr->getDevice());
-  if (io_channel == IO_CFG_CHANNEL_GPIO) { cycle.read(io_control_addr+eGPIO_Info, EB_DATA32, &inputOffset); }
-  if (io_channel == IO_CFG_CHANNEL_LVDS) { cycle.read(io_control_addr+eLVDS_Info, EB_DATA32, &inputOffset); }
+  if      (io_channel == IO_CFG_CHANNEL_GPIO) { cycle.read(io_control_addr+eGPIO_Info, EB_DATA32, &inputOffset); }
+  else if (io_channel == IO_CFG_CHANNEL_LVDS) { cycle.read(io_control_addr+eLVDS_Info, EB_DATA32, &inputOffset); }
   else                                   { throw saftbus::Error(saftbus::Error::INVALID_ARGS, "IO channel unknown!"); }
   cycle.close();
   totalInputs = (unsigned) inputOffset;


### PR DESCRIPTION
Fix the following error: for example on an SCU:

$ saft-io-ctl tr0 -n B1
IO:
  Path:    /de/gsi/saftlib/tr0/outputs/B1
  Partner: /de/gsi/saftlib/tr0/inputs/B1

Current state:
  Output:           Low
Failed to invoke method: IO channel unknown!  <= this exception shouldn't be 
