### PR TITLE
NIM TTL logic level

### DIFF
--- a/drivers/InoutImpl.cpp
+++ b/drivers/InoutImpl.cpp
@@ -975,10 +975,28 @@ std::string InoutImpl::getLogicLevel() const
 
   switch(io_logic_level)
   {
-    case IO_LOGIC_LEVEL_TTL:   { IOLogicLevel = "TTL";   break; }
+    case IO_LOGIC_LEVEL_TTL:   { // display the correct level if the special function is level conversion
+      if (io_special_purpose == IO_SPECIAL_TTL_TO_NIM) {
+        if ( (io_spec_out_available && getSpecialPurposeOut()) || (io_spec_in_available  && getSpecialPurposeIn())) {
+          IOLogicLevel = "NIM";
+        } 
+      } else {
+        IOLogicLevel = "TTL";   
+      }
+    }
+    break; 
     case IO_LOGIC_LEVEL_LVTTL: { IOLogicLevel = "LVTTL"; break; }
     case IO_LOGIC_LEVEL_LVDS:  { IOLogicLevel = "LVDS";  break; }
-    case IO_LOGIC_LEVEL_NIM:   { IOLogicLevel = "NIM";   break; }
+    case IO_LOGIC_LEVEL_NIM:   { // display the correct level if the special function is level conversion
+      if (io_special_purpose == IO_SPECIAL_TTL_TO_NIM) {
+        if ( (io_spec_out_available && getSpecialPurposeOut()) || (io_spec_in_available  && getSpecialPurposeIn())) {
+          IOLogicLevel = "TTL";
+        } 
+      } else {
+        IOLogicLevel = "NIM";   
+      }
+    }
+    break; 
     case IO_LOGIC_LEVEL_CMOS:  { IOLogicLevel = "CMOS";  break; }
     default:                   { IOLogicLevel = "?";     break; }
   }

--- a/drivers/InoutImpl.cpp
+++ b/drivers/InoutImpl.cpp
@@ -976,25 +976,23 @@ std::string InoutImpl::getLogicLevel() const
   switch(io_logic_level)
   {
     case IO_LOGIC_LEVEL_TTL:   { // display the correct level if the special function is level conversion
+      IOLogicLevel = "TTL";   
       if (io_special_purpose == IO_SPECIAL_TTL_TO_NIM) {
         if ( (io_spec_out_available && getSpecialPurposeOut()) || (io_spec_in_available  && getSpecialPurposeIn())) {
           IOLogicLevel = "NIM";
         } 
-      } else {
-        IOLogicLevel = "TTL";   
-      }
+      } 
     }
     break; 
     case IO_LOGIC_LEVEL_LVTTL: { IOLogicLevel = "LVTTL"; break; }
     case IO_LOGIC_LEVEL_LVDS:  { IOLogicLevel = "LVDS";  break; }
     case IO_LOGIC_LEVEL_NIM:   { // display the correct level if the special function is level conversion
+      IOLogicLevel = "NIM";   
       if (io_special_purpose == IO_SPECIAL_TTL_TO_NIM) {
         if ( (io_spec_out_available && getSpecialPurposeOut()) || (io_spec_in_available  && getSpecialPurposeIn())) {
           IOLogicLevel = "TTL";
         } 
-      } else {
-        IOLogicLevel = "NIM";   
-      }
+      } 
     }
     break; 
     case IO_LOGIC_LEVEL_CMOS:  { IOLogicLevel = "CMOS";  break; }

--- a/drivers/io_control_regs.h
+++ b/drivers/io_control_regs.h
@@ -62,6 +62,14 @@
 #define IO_SPECIAL_OUT_SHIFT         1
 #define IO_SPECIAL_IN_SHIFT          0
 
+#define IO_SPECIAL_MTCA4_BPL_BUF_OE    6
+#define IO_SPECIAL_LIBERA_TRIG_OE      5
+#define IO_SPECIAL_MTCA4_FAILSAFE_EN   4
+#define IO_SPECIAL_MTCA4_TRIG_BPL_PDN  3
+#define IO_SPECIAL_CLK_IN_EN           2
+#define IO_SPECIAL_TTL_TO_NIM          1
+#define IO_SPECIAL_NONE                0
+
 #define IO_CFG_FIELD_DIR_MASK        0xc0
 #define IO_CFG_FIELD_INFO_CHAN_MASK  0x38
 #define IO_CFG_FIELD_OE_MASK         0x04


### PR DESCRIPTION
If the special purpose of an IO changes the logic-level (NIM or TTL), the return value of  getLogicLevelOut() and getLogicLevelIn() should change when the special purpose flag is enabled. 

This is implemented here. As far as I know, the vetar2a IOs "IN" and "OUT" are the only IOs for which this is relevant.

