### PR TITLE
saft-*: Handle empty device list for `-f`flag

### DIFF
--- a/src/saft-ctl.cpp
+++ b/src/saft-ctl.cpp
@@ -534,6 +534,10 @@ int main(int argc, char** argv)
     map<std::string, std::string> devices = SAFTd_Proxy::create()->getDevices();
     std::shared_ptr<TimingReceiver_Proxy> receiver;
     if (useFirstDev) {
+      if (devices.empty()) {
+          std::cerr << "No devices attached to saftd" << std::endl;
+          return -1;
+      }
       receiver = TimingReceiver_Proxy::create(devices.begin()->second);
     } else {
       if (devices.find(deviceName) == devices.end()) {

--- a/src/saft-dm.cpp
+++ b/src/saft-dm.cpp
@@ -161,6 +161,10 @@ int main(int argc, char** argv)
     map<std::string, std::string> devices = SAFTd_Proxy::create()->getDevices();
     std::shared_ptr<TimingReceiver_Proxy> receiver;
     if (useFirstDev) {
+      if (devices.empty()) {
+          std::cerr << "No devices attached to saftd" << std::endl;
+          return -1;
+      }
       receiver = TimingReceiver_Proxy::create(devices.begin()->second);
     } else {
       if (devices.find(deviceName) == devices.end()) {

--- a/src/saft-gmt-check.cpp
+++ b/src/saft-gmt-check.cpp
@@ -240,6 +240,10 @@ int main(int argc, char** argv)
     map<std::string, std::string> devices = SAFTd_Proxy::create()->getDevices();
     std::shared_ptr<TimingReceiver_Proxy> receiver;
     if (useFirstDev) {
+      if (devices.empty()) {
+          std::cerr << "No devices attached to saftd" << std::endl;
+          return -1;
+      }
       receiver = TimingReceiver_Proxy::create(devices.begin()->second);
     } else {
       if (devices.find(deviceName) == devices.end()) {

--- a/src/saft-lcd.cpp
+++ b/src/saft-lcd.cpp
@@ -323,6 +323,10 @@ int main(int argc, char** argv)
     map<std::string, std::string> devices = SAFTd_Proxy::create()->getDevices();
     std::shared_ptr<TimingReceiver_Proxy> receiver;
     if (useFirstDev) {
+      if (devices.empty()) {
+          std::cerr << "No devices attached to saftd" << std::endl;
+          return -1;
+      }
       receiver = TimingReceiver_Proxy::create(devices.begin()->second);
     } else {
       if (devices.find(deviceName) == devices.end()) {

--- a/src/saft-uni.cpp
+++ b/src/saft-uni.cpp
@@ -435,6 +435,10 @@ int main(int argc, char** argv)
     map<std::string, std::string> devices = SAFTd_Proxy::create()->getDevices();
     std::shared_ptr<TimingReceiver_Proxy> receiver;
     if (useFirstDev) {
+      if (devices.empty()) {
+          std::cerr << "No devices attached to saftd" << std::endl;
+          return -1;
+      }
       receiver = TimingReceiver_Proxy::create(devices.begin()->second);
     } else {
       if (devices.find(deviceName) == devices.end()) {


### PR DESCRIPTION
If the saftd service does not have any devices attached, `Saftd_Proxy::create()->getDevices()` will return an empty map. This change checks for this edge case before trying to create a `TimingReceiverProxy` which will fail with `std::bad_alloc` otherwise. With this change an error message is printed and an error code of -1 is returned, which matches the behaviour of calling `saft-* <nonexistent device> ...`.

fixes #108 

```
[nix-shell:~/timing]$ saft-ctl bla -fjks
devices attached on this host   : 1
  device: /de/gsi/saftlib/tr0, name: tr0, path: dev/wbm0, gatewareVersion : 6.1.2
  --gateware version info:
  ---- Mon Aug 09 08:48:31 CEST 2021
  ---- fallout-v6.1.2
  ---- Arria V (5agxma3d4f27i3)
  ---- CentOS Linux release 7.9.2009 (Core), kernel 3.10.0-1160.36.2.el7.x86_64
  ---- pexaria5 +db[12] +wrex1
  ---- Timing Group Jenkins <csco-tg@gsi.de>
  ---- tsl021.acc.gsi.de
  ---- pci_control
  ---- Version 18.1.0 Build 625 09/12/2018 SJ Standard Edition
  ---- fallout-3847

6.1.2
no WR lock!!!
receiver free conditions: 256, max (capacity of HW): 0(256), early threshold: 4294967296 ns, latency: 4096 ns
sinks instantiated on this host: 1
  /de/gsi/saftlib/tr0/software/_3 (minOffset: -1000000000 ns, maxOffset: 1000000000 ns)
  -- actions: 0, delayed: 0, conflict: 0, late: 0, early: 0, overflow: 0 (max signalRate: 10Hz)
  -- conditions: 0

[nix-shell:~/timing]$ saft-ctl tr0 remove
Device 'tr0' was removed

[nix-shell:~/timing]$ saft-ctl bla -fs  # this command would crash with std::bad_alloc without this change
No devices attached to saftd
```