### PR TITLE
Compatibility with v2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -275,6 +275,9 @@ libsaft_proxy_include_HEADERS = \
 	src/LM32Cluster_Proxy.hpp                                  \
 	src/TimingReceiver_Proxy.hpp                                \
 	src/CommonFunctions.hpp                                     \
+	src/Error.h                                                 \
+	src/Time.h                                                  \
+	src/SignalGroup.h                                           \
 	src/interfaces/saftbus.h                                    \
 	src/interfaces/saftlib.h                                    \
 	src/interfaces/SAFTd.h                                      \
@@ -312,7 +315,15 @@ libsaft_proxy_include_HEADERS = \
 	src/interfaces/iOutputActionSink.h                          \
 	src/interfaces/OutputCondition.h                            \
 	src/interfaces/iCondition.h                                 \
-	src/interfaces/iOutputCondition.h
+	src/interfaces/iOutputCondition.h                           \
+	src/interfaces/FunctionGeneratorFirmware.h                  \
+	src/interfaces/iFunctionGeneratorFirmware.h                 \
+	src/interfaces/FunctionGenerator.h                          \
+	src/interfaces/iFunctionGenerator.h                         \
+	src/interfaces/MasterFunctionGenerator.h                    \
+	src/interfaces/iMasterFunctionGenerator.h                   \
+	src/interfaces/BurstGenerator.h                             \
+	src/interfaces/iBurstGenerator.h    
 
 
 if GIT_TREE
@@ -359,7 +370,8 @@ libfg_firmware_proxy_includedir = $(includedir)/fg-firmware
 libfg_firmware_proxy_include_HEADERS =        \
 	src/FunctionGenerator_Proxy.hpp          \
 	src/MasterFunctionGenerator_Proxy.hpp     \
-	src/FunctionGeneratorFirmware_Proxy.hpp   
+	src/FunctionGeneratorFirmware_Proxy.hpp    
+
 
 
 
@@ -383,9 +395,10 @@ libbg_firmware_proxy_la_LIBADD  =  $(SIGCPP_LIBS) libsaftbus.la
 libbg_firmware_proxy_la_SOURCES =   \
 	src/BurstGenerator_Proxy.cpp                   
 
-libbg_firmware_proxy_includedir = $(includedir)/bg
+libbg_firmware_proxy_includedir = $(includedir)/bg-firmware
 libbg_firmware_proxy_include_HEADERS = \
-	src/BurstGenerator_Proxy.hpp                
+	src/BurstGenerator_Proxy.hpp          
+
 
 
 

--- a/src/Error.h
+++ b/src/Error.h
@@ -1,0 +1,7 @@
+#ifndef ERROR_COMPATIBILITY_H_
+#define ERROR_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/FunctionGeneratorFirmware.hpp
+++ b/src/FunctionGeneratorFirmware.hpp
@@ -46,18 +46,8 @@ class FunctionGeneratorFirmware : public Owned, public TimingReceiverAddon
 
     FunctionGeneratorFirmware(saftbus::Container *container, SAFTd *saft_daemon, TimingReceiver *timing_receiver);
     ~FunctionGeneratorFirmware();
-    // typedef FunctionGeneratorFirmware_Service ServiceType;
-    // struct ConstructorType {
-    //   std::string objectPath;
-    //   TimingReceiver  *tr;
-    //   Device &device;
-    //   etherbone::sdb_msi_device  sdb_msi_base;
-    //   sdb_device                 mailbox;
-    //   std::map< std::string, std::shared_ptr<Owned> > &fgs_owned;
-    //   std::map< std::string, std::shared_ptr<Owned> > &master_fgs_owned;
-    // };
-    // static std::shared_ptr<FunctionGeneratorFirmware> create(const ConstructorType& args);
-    
+
+    // @saftbus-export
     uint32_t getVersion() const;
 
     /// @brief Scan bus for fg channels. 

--- a/src/SignalGroup.h
+++ b/src/SignalGroup.h
@@ -1,0 +1,7 @@
+#ifndef SIGNALGROUP_COMPATIBILITY_H_
+#define SIGNALGROUP_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/Time.h
+++ b/src/Time.h
@@ -1,0 +1,8 @@
+#ifndef TIME_COMPATIBILITY_H_
+#define TIME_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <Time.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/interfaces/BurstGenerator.h
+++ b/src/interfaces/BurstGenerator.h
@@ -1,0 +1,8 @@
+#ifndef BURSTGENERATOR_COMPATIBILITY_H_
+#define BURSTGENERATOR_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <bg-firmware/BurstGenerator_Proxy.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/interfaces/FunctionGenerator.h
+++ b/src/interfaces/FunctionGenerator.h
@@ -1,0 +1,8 @@
+#ifndef FUNCTIONGENERATOR_COMPATIBILITY_H_
+#define FUNCTIONGENERATOR_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <fg-firmware/FunctionGenerator_Proxy.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/interfaces/FunctionGeneratorFirmware.h
+++ b/src/interfaces/FunctionGeneratorFirmware.h
@@ -1,0 +1,8 @@
+#ifndef FUNCTIONGENERATORFIRMWARE_COMPATIBILITY_H_
+#define FUNCTIONGENERATORFIRMWARE_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <fg-firmware/FunctionGeneratorFirmware_Proxy.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/interfaces/MasterFunctionGenerator.h
+++ b/src/interfaces/MasterFunctionGenerator.h
@@ -1,0 +1,8 @@
+#ifndef MASTERFUNCTIONGENERATOR_COMPATIBILITY_H_
+#define MASTERFUNCTIONGENERATOR_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <fg-firmware/MasterFunctionGenerator_Proxy.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/interfaces/iBurstGenerator.h
+++ b/src/interfaces/iBurstGenerator.h
@@ -1,0 +1,8 @@
+#ifndef IBURSTGENERATOR_COMPATIBILITY_H_
+#define IBURSTGENERATOR_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <bg-firmware/BurstGenerator_Proxy.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/interfaces/iFunctionGenerator.h
+++ b/src/interfaces/iFunctionGenerator.h
@@ -1,0 +1,8 @@
+#ifndef IFUNCTIONGENERATOR_COMPATIBILITY_H_
+#define IFUNCTIONGENERATOR_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <fg-firmware/FunctionGenerator_Proxy.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/interfaces/iFunctionGeneratorFirmware.h
+++ b/src/interfaces/iFunctionGeneratorFirmware.h
@@ -1,0 +1,8 @@
+#ifndef IFUNCTIONGENERATORFIRMWARE_COMPATIBILITY_H_
+#define IFUNCTIONGENERATORFIRMWARE_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <fg-firmware/FunctionGeneratorFirmware_Proxy.hpp>
+#include <CommonFunctions.hpp>
+
+#endif

--- a/src/interfaces/iMasterFunctionGenerator.h
+++ b/src/interfaces/iMasterFunctionGenerator.h
@@ -1,0 +1,8 @@
+#ifndef IMASTERFUNCTIONGENERATOR_COMPATIBILITY_H_
+#define IMASTERFUNCTIONGENERATOR_COMPATIBILITY_H_
+
+#include <saftbus/error.hpp>
+#include <fg-firmware/MasterFunctionGenerator_Proxy.hpp>
+#include <CommonFunctions.hpp>
+
+#endif


### PR DESCRIPTION
Add missing compatibility header files (mainly for the firmware plugins). These headers allow projects developed against previous saftlib versions to be compiled against latest version without changes.
Also add one missing saftbus-export tag.