### PR TITLE
saftbus: count dropped signals

### DIFF
--- a/saftbus-gen/saftbus-gen.cpp
+++ b/saftbus-gen/saftbus-gen.cpp
@@ -1176,7 +1176,7 @@ void generate_service_implementation(const std::string &outputdirectory, ClassDe
 				}
 			}
 			out << ") {" << std::endl;
-			// out << "\t\t" << "std::cerr << \"service dispatch function called!!!!!!!!!!!!\" << std::endl;" << std::endl;
+			// out << "\t\t" << "std::cerr << \"service "<< class_definition.name << "::" << signal.name << " dispatch function called\" << std::endl;" << std::endl;
 			out << "\t\t" << "saftbus::Serializer serialized_signal;" << std::endl;
 			out << "\t\t" << "serialized_signal.put(get_object_id());" << std::endl;
 			out << "\t\t" << "serialized_signal.put(" << interface_no    << ");" << std::endl;

--- a/saftbus/client.hpp
+++ b/saftbus/client.hpp
@@ -190,7 +190,7 @@ namespace saftbus {
 			unsigned object_id;
 			std::string object_path;
 			std::vector<std::string> interface_names;
-			std::map<int, int> signal_fds_use_count;
+			std::map<int, std::pair<int, int> > signal_fds_use_count_and_dropped_signals;
 			int owner;
 			bool has_destruction_callback;
 			bool destroy_if_owner_quits;
@@ -199,7 +199,7 @@ namespace saftbus {
 				ser.put(object_id);
 				ser.put(object_path);
 				ser.put(interface_names);
-				ser.put(signal_fds_use_count);
+				ser.put(signal_fds_use_count_and_dropped_signals);
 				ser.put(owner);
 				ser.put(has_destruction_callback);
 				ser.put(destroy_if_owner_quits);
@@ -209,7 +209,7 @@ namespace saftbus {
 				des.get(object_id);
 				des.get(object_path);
 				des.get(interface_names);
-				des.get(signal_fds_use_count);
+				des.get(signal_fds_use_count_and_dropped_signals);
 				des.get(owner);
 				des.get(has_destruction_callback);
 				des.get(destroy_if_owner_quits);

--- a/saftbus/saftbus-ctl.cpp
+++ b/saftbus/saftbus-ctl.cpp
@@ -59,7 +59,7 @@ void print_status(saftbus::SaftbusInfo &saftbus_info) {
 	}
 	std::cout << "services:" << std::endl;
 	std::cout << "  " << std::setw(max_object_path_length) << std::left << "object-path" 
-	          << " ID [owner] sig-fd/use-count interface-names" << std::endl;
+	          << " ID [owner] sig-fd/use-count/dropped-signals interface-names" << std::endl;
 	std::vector<std::string> services;	          
 	for (auto &object: saftbus_info.object_infos) {
 		std::ostringstream line;
@@ -73,8 +73,8 @@ void print_status(saftbus::SaftbusInfo &saftbus_info) {
 		else if (object.has_destruction_callback && !object.destroy_if_owner_quits) line << "d ";
 		else line << "  ";
 
-		for (auto &user: object.signal_fds_use_count) {
-			line << user.first << "/" << user.second << " ";
+		for (auto &fd_user_dropped: object.signal_fds_use_count_and_dropped_signals) {
+			line << fd_user_dropped.first << "/" << fd_user_dropped.second.first << "/" << fd_user_dropped.second.second << " ";
 		}
 		for (auto &interface: object.interface_names) {
 			line << interface << " ";


### PR DESCRIPTION
saftbusd drops signals are if the file descriptor for the signal (socketpair) is not ready to take data

This commit allows to see the number of dropped signals with "saftbus-ctl -s" for each saftbus service-object

```bash
$ saftbus-ctl -s
services:
  object-path                                   ID [owner] sig-fd/use-count/dropped-signals interface-names
  /de/gsi/saftlib                               2 [-1]d 11/1/0 13/1/0 SAFTd 
  /de/gsi/saftlib/tr0                           3 [-1]d 11/1/0 13/1/0 TimingReceiver BuildIdRom ECA ECA_Event ECA_TLU LM32Cluster Mailbox OpenDevice Reset TempSensor Watchdog WhiteRabbit 
  /de/gsi/saftlib/tr0/software/_1               4 [10]D 11/1/419 SoftwareActionSink ActionSink Owned 
  /de/gsi/saftlib/tr0/software/_1/_1025202362   5 [10]D 11/1/132 SoftwareCondition Condition Owned 
  /de/gsi/saftlib/tr0/software/_294             298 [12]D 13/1/0 SoftwareActionSink ActionSink Owned 
  /de/gsi/saftlib/tr0/software/_294/_1366405247 299 [12]D 13/1/0 SoftwareCondition Condition Owned 
  /saftbus                                      1 [-1]  15/1/0 Container 
```
for example here, 419 dropped signals:
  /de/gsi/saftlib/tr0/software/_1               4 [10]D 11/1/419 SoftwareActionSink ActionSink Owned 
zero dropped signals here:
  /de/gsi/saftlib/tr0/software/_294             298 [12]D 13/1/0 SoftwareActionSink ActionSink Owned 



