### PR TITLE
saft-wbm-ctl: support for macros spanning multiple bus operations 

### DIFF
--- a/src/WbmActionCmd.hpp
+++ b/src/WbmActionCmd.hpp
@@ -1,0 +1,10 @@
+#ifndef WBM_ACTION_CMD_HPP_
+#define WBM_ACTION_CMD_HPP_
+
+struct WbmActionCmd {
+	uint32_t adr;
+	uint32_t data;
+	uint32_t flags;
+};
+
+#endif

--- a/src/WbmActionSink.cpp
+++ b/src/WbmActionSink.cpp
@@ -83,13 +83,12 @@ void WbmActionSink::ReadMacroFile(const std::string& fn, std::vector<WbmActionCm
   
 }
 
-void WbmActionSink::RecordMacro(uint32_t idx, std::vector<WbmActionCmd>& commands) {
-    
+void WbmActionSink::RecordMacro(uint32_t idx, std::vector<WbmActionCmd> commands) {
   etherbone::Cycle cycle;
   cycle.open(device);
   cycle.write(acwbm + SLAVE_REC_OWR, EB_DATA32, (eb_data_t) idx); // start recording
   
-  for(unsigned cmd_idx = 0; cmd_idx < commands.size(); ++cmd_idx) {
+  for(unsigned cmd_idx = 0; cmd_idx < commands.size(); cmd_idx++) {
     cycle.write(acwbm + SLAVE_REC_FIFO_OWR, EB_DATA32, (eb_data_t)commands[cmd_idx].adr);
     cycle.write(acwbm + SLAVE_REC_FIFO_OWR, EB_DATA32, (eb_data_t)commands[cmd_idx].data);
     cycle.write(acwbm + SLAVE_REC_FIFO_OWR, EB_DATA32, (eb_data_t)commands[cmd_idx].flags);

--- a/src/WbmActionSink.cpp
+++ b/src/WbmActionSink.cpp
@@ -58,18 +58,19 @@ void WbmActionSink::ExecuteMacro(uint32_t idx) {
   device.write(acwbm + SLAVE_EXEC_OWR, EB_DATA32, data);
 }
 
-void WbmActionSink::RecordMacro(uint32_t idx, std::vector<WbmActionCmd> commands) {
+void WbmActionSink::RecordMacro(uint32_t idx, const std::vector<WbmActionCmd>& commands) {
   
-  for(unsigned cmd_idx = 0; cmd_idx < commands.size(); cmd_idx++) {
-    std::cerr << "Adr " << std::hex << commands[cmd_idx].adr << std::endl;
-    std::cerr << "Dat " << std::hex << commands[cmd_idx].data << std::endl;
-    std::cerr << "Flg " << std::hex << commands[cmd_idx].flags << std::endl;
+  try {  device.write(acwbm + SLAVE_REC_OWR, EB_DATA32, (eb_data_t) idx); /* start recording */ }
+  catch (etherbone::exception_t e)
+  { throw saftbus::Error(
+      saftbus::Error::INVALID_ARGS,
+      (std::ostringstream() << "Recording failed. Macro idx '" << idx << "' is occupied or wbm-as out of macro memory. Choose a free index or delete macro(s)").str()
+    );
   }
 
   etherbone::Cycle cycle;
-  cycle.open(device);
-  cycle.write(acwbm + SLAVE_REC_OWR, EB_DATA32, (eb_data_t) idx); // start recording
   
+  cycle.open(device);
   for(unsigned cmd_idx = 0; cmd_idx < commands.size(); cmd_idx++) {
     cycle.write(acwbm + SLAVE_REC_FIFO_OWR, EB_DATA32, (eb_data_t)commands[cmd_idx].adr);
     cycle.write(acwbm + SLAVE_REC_FIFO_OWR, EB_DATA32, (eb_data_t)commands[cmd_idx].data);

--- a/src/WbmActionSink.cpp
+++ b/src/WbmActionSink.cpp
@@ -31,7 +31,6 @@
 
 #include <cassert>
 #include <sstream>
-#include <fstream>
 #include <memory>
 
 namespace saftlib {
@@ -59,31 +58,14 @@ void WbmActionSink::ExecuteMacro(uint32_t idx) {
   device.write(acwbm + SLAVE_EXEC_OWR, EB_DATA32, data);
 }
 
-void WbmActionSink::ReadMacroFile(const std::string& fn, std::vector<WbmActionCmd>& commands) {
-  std::ifstream infile(fn);
-  std::string line;
-
-  if (!infile.is_open()) {
-      std::cerr << "Error: Could not open file " << fn << std::endl;
-      return;
-  }
-
-  while (std::getline(infile, line)) {
-    std::istringstream iss(line);
-    uint32_t adr, data, flags;
-
-    if (!(iss >> std::ws >> std::hex >> adr >> std::hex >> data >> std::hex >> flags)) {
-        std::cerr << "Warning: Skipping malformed line: " << line << std::endl;
-        continue;
-    }
-      
-    commands.push_back(WbmActionCmd({adr, data, flags}));
-  }
-
-  
-}
-
 void WbmActionSink::RecordMacro(uint32_t idx, std::vector<WbmActionCmd> commands) {
+  
+  for(unsigned cmd_idx = 0; cmd_idx < commands.size(); cmd_idx++) {
+    std::cerr << "Adr " << std::hex << commands[cmd_idx].adr << std::endl;
+    std::cerr << "Dat " << std::hex << commands[cmd_idx].data << std::endl;
+    std::cerr << "Flg " << std::hex << commands[cmd_idx].flags << std::endl;
+  }
+
   etherbone::Cycle cycle;
   cycle.open(device);
   cycle.write(acwbm + SLAVE_REC_OWR, EB_DATA32, (eb_data_t) idx); // start recording

--- a/src/WbmActionSink.hpp
+++ b/src/WbmActionSink.hpp
@@ -103,10 +103,6 @@ class WbmActionSink : public ActionSink {
 	    // Property setters
 	    // @saftbus-export
 	    void setEnable(bool val);
-	    // @saftbus-export
-	    void ReadMacroFile(const std::string& fn, std::vector<WbmActionCmd>& commands);
-			
-		
 
 	protected:
 		etherbone::Device &device;

--- a/src/WbmActionSink.hpp
+++ b/src/WbmActionSink.hpp
@@ -94,10 +94,18 @@ class WbmActionSink : public ActionSink {
     // Property setters
     // @saftbus-export
     void setEnable(bool val);
+    // @saftbus-export
+    void ReadMacroFile(const std::string& fn, const std::vector<WbmActionCmd>& commands);
 		
 	protected:
 		etherbone::Device &device;
 		eb_address_t acwbm;
+};
+
+struct WbmActionCmd {
+	uint32_t adr;
+	uint32_t dat;
+	uint32_t flags;
 };
 
 }

--- a/src/WbmActionSink.hpp
+++ b/src/WbmActionSink.hpp
@@ -82,7 +82,7 @@ class WbmActionSink : public ActionSink {
 	    // @saftbus-export
 	    void ExecuteMacro(uint32_t idx);
 	    // @saftbus-export
-	    void RecordMacro(uint32_t idx, std::vector<WbmActionCmd>& commands);
+	    void RecordMacro(uint32_t idx, std::vector<WbmActionCmd> commands);
 	    // @saftbus-export
 	    void ClearMacro(uint32_t idx);
 	    // @saftbus-export

--- a/src/WbmActionSink.hpp
+++ b/src/WbmActionSink.hpp
@@ -82,7 +82,7 @@ class WbmActionSink : public ActionSink {
 	    // @saftbus-export
 	    void ExecuteMacro(uint32_t idx);
 	    // @saftbus-export
-	    void RecordMacro(uint32_t idx, std::vector<WbmActionCmd> commands);
+	    void RecordMacro(uint32_t idx, const std::vector<WbmActionCmd>& commands);
 	    // @saftbus-export
 	    void ClearMacro(uint32_t idx);
 	    // @saftbus-export

--- a/src/WbmActionSink.hpp
+++ b/src/WbmActionSink.hpp
@@ -31,7 +31,13 @@
 
 #include "ActionSink.hpp"
 
+// @saftbus-export
+#include "WbmActionCmd.hpp"
+
 namespace saftlib {
+
+
+
 
 /// de.gsi.saftlib.WbmActionSink:
 /// @brief An output through which Wbm actions flow.
@@ -66,47 +72,50 @@ class WbmActionSink : public ActionSink {
 		/// to determine the timestamp when the matching condition fires its
 		/// action.  The returned object path is a SCUBUSCondition object.
 		///
+
+		
+
 		// @saftbus-export
 		std::string NewCondition(bool active, uint64_t id, uint64_t mask, int64_t offset, uint32_t tag);
 
     
-    // @saftbus-export
-    void ExecuteMacro(uint32_t idx);
-    // @saftbus-export
-    void RecordMacro(uint32_t idx, const std::vector< std::vector< uint32_t > >& commands);
-    // @saftbus-export
-    void ClearMacro(uint32_t idx);
-    // @saftbus-export
-    void ClearAllMacros();
-    // Property getters
-    // @saftbus-export
-    unsigned char getStatus() const;
-    // @saftbus-export
-    uint32_t getMaxMacros() const;
-    // @saftbus-export
-    uint32_t getMaxSpace() const;
-    // @saftbus-export
-    bool getEnable() const;
-    // @saftbus-export
-    uint32_t getLastExecutedIdx() const;
-    // @saftbus-export
-    uint32_t getLastRecordedIdx() const;
-    // Property setters
-    // @saftbus-export
-    void setEnable(bool val);
-    // @saftbus-export
-    void ReadMacroFile(const std::string& fn, const std::vector<WbmActionCmd>& commands);
+	    // @saftbus-export
+	    void ExecuteMacro(uint32_t idx);
+	    // @saftbus-export
+	    void RecordMacro(uint32_t idx, std::vector<WbmActionCmd>& commands);
+	    // @saftbus-export
+	    void ClearMacro(uint32_t idx);
+	    // @saftbus-export
+	    void ClearAllMacros();
+	    // Property getters
+	    // @saftbus-export
+	    unsigned char getStatus() const;
+	    // @saftbus-export
+	    uint32_t getMaxMacros() const;
+	    // @saftbus-export
+	    uint32_t getMaxSpace() const;
+	    // @saftbus-export
+	    bool getEnable() const;
+	    // @saftbus-export
+	    uint32_t getLastExecutedIdx() const;
+	    // @saftbus-export
+	    uint32_t getLastRecordedIdx() const;
+	    // Property setters
+	    // @saftbus-export
+	    void setEnable(bool val);
+	    // @saftbus-export
+	    void ReadMacroFile(const std::string& fn, std::vector<WbmActionCmd>& commands);
+			
 		
+
 	protected:
 		etherbone::Device &device;
 		eb_address_t acwbm;
+
+	
 };
 
-struct WbmActionCmd {
-	uint32_t adr;
-	uint32_t dat;
-	uint32_t flags;
-};
+
 
 }
 

--- a/src/saft-ecpu-ctl.cpp
+++ b/src/saft-ecpu-ctl.cpp
@@ -49,7 +49,7 @@ static void ecpu_help (void)
   std::cout << "  -d:                            Disown the created condition" << std::endl;
   std::cout << "  -g                             Negative offset (new condition)" << std::endl;
   std::cout << "  -x:                            Destroy all unowned conditions" << std::endl;
-  std::cout << "  -z                             Translate mask" << std::endl;
+  std::cout << "  -z                             Translate mask, e.g. '16' -> '0xffff00000000'" << std::endl;
   std::cout << "  -l                             List conditions" << std::endl;
   std::cout << "  -h:                            Print help (this message)" << std::endl;
   std::cout << "  -v:                            Switch to verbose mode" << std::endl;
@@ -138,9 +138,11 @@ int main (int argc, char** argv)
   /* List parameters */
   if (verbose_mode && create_sink)
   {
+    uint64_t mask = translate_mask ? tr_mask(eventMask) : eventMask;
+    
     std::cout << "Action sink/condition parameters:" << std::endl;
     std::cout << std::hex << "EventID:   0x" << eventID   << std::dec << " (" << eventID   << ")" << std::endl;
-    std::cout << std::hex << "EventMask: 0x" << eventMask << std::dec << " (" << eventMask << ")" << std::endl;
+    std::cout << std::hex << "EventMask: 0x" << mask      << std::dec << " (" << mask      << ")" << std::endl;
     std::cout << std::hex << "Offset:    0x" << offset    << std::dec << " (" << offset    << ")" << std::endl;
     std::cout << std::hex << "Tag:       0x" << tag       << std::dec << " (" << tag       << ")" << std::endl;
   }

--- a/src/saft-scu-ctl.cpp
+++ b/src/saft-scu-ctl.cpp
@@ -47,7 +47,7 @@ static void scu_help (void)
   std::cout << "  -d:                            Disown the created condition" << std::endl;
   std::cout << "  -g                             Negative offset (new condition)" << std::endl;
   std::cout << "  -x:                            Destroy all unowned conditions" << std::endl;
-  std::cout << "  -z                             Translate mask" << std::endl;
+  std::cout << "  -z                             Translate mask, e.g. '16' -> '0xffff00000000'" << std::endl;
   std::cout << "  -l                             List conditions" << std::endl;
   std::cout << "  -h:                            Print help (this message)" << std::endl;
   std::cout << "  -v:                            Switch to verbose mode" << std::endl;
@@ -136,9 +136,10 @@ int main (int argc, char** argv)
   /* List parameters */
   if (verbose_mode && create_sink)
   {
+    uint64_t mask = translate_mask ? tr_mask(eventMask) : eventMask;
     std::cout << "Action sink/condition parameters:" << std::endl;
     std::cout << std::hex << "EventID:   0x" << eventID   << std::dec << " (" << eventID   << ")" << std::endl;
-    std::cout << std::hex << "EventMask: 0x" << eventMask << std::dec << " (" << eventMask << ")" << std::endl;
+    std::cout << std::hex << "EventMask: 0x" << mask      << std::dec << " (" << mask      << ")" << std::endl;
     std::cout << std::hex << "Offset:    0x" << offset    << std::dec << " (" << offset    << ")" << std::endl;
     std::cout << std::hex << "Tag:       0x" << tag       << std::dec << " (" << tag       << ")" << std::endl;
   }

--- a/src/saft-wbm-ctl.cpp
+++ b/src/saft-wbm-ctl.cpp
@@ -274,7 +274,7 @@ int main (int argc, char** argv)
     }
     else if (record_macro) 
     {
-      acwbm->setEnable(false);
+
       std::vector<WbmActionCmd> commands;
       if (macro_file) {
         std::ifstream infile(filename);
@@ -284,7 +284,6 @@ int main (int argc, char** argv)
         }
 
         std::string line;
-
         while (std::getline(infile, line)) {
           std::istringstream iss(line);
           uint32_t adr, data, flags;
@@ -298,12 +297,21 @@ int main (int argc, char** argv)
       } else {
         commands.push_back(WbmActionCmd({macroAdr, macroDat, macroFlags}));
       }
-      if(commands.size()) acwbm->RecordMacro(macroIdx, commands);
-      else {
+
+      if(commands.size() > 0) {
+        if(verbose_mode) {
+            std::cout << "Adding Macro at index " << macroIdx << ":" << std::endl;
+            for(auto it : commands) {
+              std::cout << "Adr 0x" << std::hex << it.adr << " Dat 0x" << it.data << " Flg 0x" << it.flags << std::endl;
+            }
+        }
+        acwbm->setEnable(false);
+        acwbm->RecordMacro(macroIdx, commands);
+        acwbm->setEnable(true);
+      } else {
         std::cerr << "Error: Could not find macro commands to add" << std::endl;
         return -1;
       }  
-      acwbm->setEnable(true);
     }
     else if (destroy_sink)
     {

--- a/src/saft-wbm-ctl.cpp
+++ b/src/saft-wbm-ctl.cpp
@@ -148,6 +148,7 @@ int main (int argc, char** argv)
       }
       case 'f': { 
         macro_file = true;
+        record_macro = true;
         if (argv[optind-1] != NULL) { macroIdx = strtoull(argv[optind-1], &pEnd, 0); }
         else                        { std::cerr << "Error: Missing macro idx!" << std::endl; return (-1); }
         if (argv[optind+0] != NULL) { filename = argv[optind+0]; }

--- a/src/saft-wbm-ctl.cpp
+++ b/src/saft-wbm-ctl.cpp
@@ -90,6 +90,7 @@ int main (int argc, char** argv)
   char *pEnd           = NULL;
   bool create_sink     = false;
   bool record_macro    = false;
+  bool macro_file      = false;
   bool disown_sink     = false;
   bool destroy_sink    = false;
   bool verbose_mode    = false;
@@ -169,7 +170,7 @@ int main (int argc, char** argv)
   if (negative_offset)  { offset = -offset; }
 
   /* Plausibility check for arguments */
-  if (((create_sink || disown_sink) && destroy_sink) || (record_macro && macro_file))
+  if (((create_sink || disown_sink) && destroy_sink))
   {
     show_help = true;
     std::cerr << "Incorrect arguments!" << std::endl;
@@ -258,25 +259,10 @@ int main (int argc, char** argv)
       acwbm->setEnable(false);
       std::vector<WbmActionCmd> commands;
       if (macro_file) {
-        ReadMacroFile(filename, &commands);
+        acwbm->ReadMacroFile(filename, commands);
       } else {
-        commands.push_back(WbmActionCmd());
-        commands[0].adr   = macroAdr;
-        commands[0].data  = macroDat;
-        commands[0].flags = macroFlags;
+        commands.push_back(WbmActionCmd({macroAdr, macroDat, macroFlags}));
       }
-      acwbm->RecordMacro(macroIdx, commands);
-      acwbm->setEnable(true);
-    }
-    else if (macro_file) 
-    {
-      acwbm->setEnable(false);
-      std::vector<WbmActionCmd> commands;
-      
-      commands.push_back(WbmActionCmd());
-      commands[0].adr = macroAdr;
-      commands[0].data = macroDat;
-      commands[0].flags = macroFlags;
       acwbm->RecordMacro(macroIdx, commands);
       acwbm->setEnable(true);
     }


### PR DESCRIPTION
Added feature to saft-wbm-ctl to use a textfile for macro definition instead of single line CLI.
This finally allows utilizing the ECA's wishbone bus channel's capability to run multiple bus operations in a single action.

This is especially useful for the common task of atomically copying a 64b value from a timing message, such as the deadline or param field, which up until now took two separate rules and a delay in the ECA.