### PR TITLE
Missing libs in pkg-config

### DIFF
--- a/saftlib.pc.in
+++ b/saftlib.pc.in
@@ -7,5 +7,5 @@ Name: saftlib
 Description: Simplified API for Timing
 Requires: sigc++-2.0 saftbus
 Version: @VERSION@
-Libs: -L${libdir} -lsaft-proxy -lsaft-service -lz
+Libs: -L${libdir} -lfg-firmware-proxy -lfg-firmware-service -lsaft-proxy -lsaft-service -lz
 Cflags: -I${includedir}


### PR DESCRIPTION
Add missing libs (fg-firmware-proxy and fg-firmware-service) provided by saftlib to pkg-config